### PR TITLE
Sean/study

### DIFF
--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -3,28 +3,61 @@ Study Material API Endpoints
 Generates quizzes, flashcards, etc
 """
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
 from uuid import UUID
 from psycopg2.extras import Json
 
 from app.core.database import execute_query, execute_statement
+from app.core.supabase import supabase
 from app.models.study_materials import (
-    QuizGenerateRequest, QuizResponse, QuizSubmitRequest, QuizResultResponse, QuizDeleteResponse,
-    FlashcardRequestGenerate, FlashcardAllResponse, FlashcardReviewRequest, FlashcardResponse, FlashcardDeleteResponse,
-    SummaryGenerateRequest, SummaryResponse, AllStudyMaterialsResponse,
+    QuizGenerateRequest,
+    QuizResponse,
+    QuizSubmitRequest,
+    QuizResultResponse,
+    QuizDeleteResponse,
+    FlashcardRequestGenerate,
+    FlashcardAllResponse,
+    FlashcardReviewRequest,
+    FlashcardResponse,
+    FlashcardDeleteResponse,
+    SummaryGenerateRequest,
+    SummaryResponse,
+    AllStudyMaterialsResponse,
 )
-from app.textGeneration import generate_quiz_questions
+from app.textGeneration import generate_quiz_questions, generate_flashcard_stream, generate_summary
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+async def get_current_user(authorization: Optional[str] = Header(None)) -> Any:
+    """Validate authorization token and return current user."""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization header")
+    try:
+        token = authorization.replace("Bearer ", "")
+        user = supabase.auth.get_user(token)
+        if not user or not user.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user.user
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+
+
 # -------- QUIZ -------- #
 
+
 @router.post("/quiz/generate", response_model=QuizResponse)
-async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
+async def quiz_generate(
+    quiz_info: QuizGenerateRequest, user=Depends(get_current_user)
+) -> QuizResponse:
     try:
         generated = generate_quiz_questions(
             piazza_course_id=quiz_info.piazza_course_id,
@@ -36,9 +69,9 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
 
         insert_query = """
         INSERT INTO quizzes (
-            piazza_course_id, title, difficulty, questions, source_posts
+            user_id, piazza_course_id, title, difficulty, questions, source_posts
         )
-        VALUES (%s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s)
         RETURNING id, title, difficulty, questions,
                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
                   created_at
@@ -46,6 +79,7 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
         quiz_row = execute_query(
             insert_query,
             (
+                str(user.id),
                 quiz_info.piazza_course_id,
                 quiz_info.title,
                 quiz_info.difficulty,
@@ -77,6 +111,7 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
             detail=f"Failed to generate quiz: {str(e)}",
         )
 
+
 @router.get("/quiz/{id}", response_model=QuizResponse)
 async def get_quiz(id: UUID) -> QuizResponse:
     try:
@@ -94,9 +129,9 @@ async def get_quiz(id: UUID) -> QuizResponse:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
             )
-        
+
         return QuizResponse.model_validate(quiz)
-    
+
     except HTTPException:
         raise
 
@@ -108,15 +143,69 @@ async def get_quiz(id: UUID) -> QuizResponse:
         )
 
 
-        
-
-
-
-    
-
 @router.post("/quiz/{id}/submit", response_model=QuizResultResponse)
-async def submit_quiz_answer(id: UUID, submission: QuizSubmitRequest) -> QuizResultResponse:
-    pass
+async def submit_quiz_answer(
+    id: UUID, submission: QuizSubmitRequest
+) -> QuizResultResponse:
+    try:
+        quiz = execute_query(
+            "SELECT id, questions FROM quizzes WHERE id = %s",
+            (str(id),),
+            fetch_one=True,
+        )
+        if not quiz:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
+            )
+
+        questions = quiz["questions"]
+        user_answers = submission.answers
+
+        if len(user_answers) != len(questions):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Expected {len(questions)} answers, got {len(user_answers)}",
+            )
+
+        correct_count = 0
+        for q, user_ans in zip(questions, user_answers):
+            correct = q["correct_answer"]
+            if isinstance(correct, list):
+                if isinstance(user_ans, list) and sorted(user_ans) == sorted(correct):
+                    correct_count += 1
+            else:
+                if user_ans == correct:
+                    correct_count += 1
+
+        total = len(questions)
+        score = round((correct_count / total) * 100, 2) if total else 0.0
+        now = datetime.now(timezone.utc)
+
+        execute_statement(
+            """
+            INSERT INTO quiz_attempts (quiz_id, answers, score, completed_at)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (str(id), Json(user_answers), score, now),
+        )
+
+        return QuizResultResponse(
+            quiz_id=id,
+            score=score,
+            correct_count=correct_count,
+            total_count=total,
+            completed_at=now,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to submit quiz")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to submit quiz: {str(e)}",
+        )
+
 
 @router.get("/quiz", response_model=list[QuizResponse])
 async def get_all_quizzes() -> list[QuizResponse]:
@@ -137,20 +226,19 @@ async def get_all_quizzes() -> list[QuizResponse]:
 
     except HTTPException:
         raise
-    
+
     except Exception as e:
         logger.exception("Failed to fetch quizzes")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to fetch quizzes: {str(e)}",
         )
-    
-    
+
 
 @router.delete("/quiz/{id}", response_model=QuizDeleteResponse)
 async def delete_quiz(id: UUID) -> QuizDeleteResponse:
     """
-    Delete given quiz from quiz id 
+    Delete given quiz from quiz id
     """
     try:
         query = """
@@ -164,7 +252,9 @@ async def delete_quiz(id: UUID) -> QuizDeleteResponse:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
             )
 
-        return QuizDeleteResponse(id=id, deleted=True, message="Quiz deleted successfully")
+        return QuizDeleteResponse(
+            id=id, deleted=True, message="Quiz deleted successfully"
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -174,34 +264,361 @@ async def delete_quiz(id: UUID) -> QuizDeleteResponse:
             detail=f"Failed to delete quiz: {str(e)}",
         )
 
+
 # -------- FLASHCARDS -------- #
 
+
 @router.post("/flashcards/generate", response_model=FlashcardAllResponse)
-async def flashcards_generate(deck_info: FlashcardRequestGenerate) -> FlashcardAllResponse:
-    pass
+async def flashcards_generate(
+    deck_info: FlashcardRequestGenerate, user=Depends(get_current_user)
+) -> FlashcardAllResponse:
+    try:
+        generated = generate_flashcard_stream(
+            piazza_course_id=deck_info.piazza_course_id,
+            title=deck_info.title,
+            tags=deck_info.tags,
+            source_posts=deck_info.source_posts,
+        )
+
+        deck_row = execute_query(
+            """
+            INSERT INTO flashcard_decks (user_id, piazza_course_id, title, tags)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, title, tags, created_at
+            """,
+            (str(user.id), deck_info.piazza_course_id, deck_info.title, deck_info.tags),
+            fetch_one=True,
+        )
+
+        if not deck_row:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to persist flashcard deck",
+            )
+
+        deck_id = deck_row["id"]
+
+        if generated["cards"]:
+            card_values = [
+                (deck_id, c["front"], c["back"], c["card_type"])
+                for c in generated["cards"]
+            ]
+            placeholders = ", ".join("(%s, %s, %s, %s)" for _ in card_values)
+            flat_params = [v for row in card_values for v in row]
+            cards_rows = execute_query(
+                f"""
+                INSERT INTO flashcards (deck_id, front, back, card_type)
+                VALUES {placeholders}
+                RETURNING id, front, back, card_type,
+                          ease_factor, interval_days, next_review, review_count
+                """,
+                tuple(flat_params),
+            )
+        else:
+            cards_rows = []
+
+        return FlashcardAllResponse(
+            id=deck_row["id"],
+            title=deck_row["title"],
+            tags=deck_row["tags"],
+            created_at=deck_row["created_at"],
+            cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to generate flashcards")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate flashcards: {str(e)}",
+        )
+
 
 @router.get("/flashcards/{deck_id}", response_model=FlashcardAllResponse)
 async def get_flashcards(deck_id: UUID) -> FlashcardAllResponse:
-    pass
+    try:
+        deck_row = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks WHERE id = %s",
+            (str(deck_id),),
+            fetch_one=True,
+        )
 
-@router.put("/flashcards/{deck_id}/progress", response_model=FlashcardResponse)
-async def update_flashcard_mastery(deck_id: UUID, review: FlashcardReviewRequest) -> FlashcardResponse:
-    pass
+        if not deck_row:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard deck not found"
+            )
+
+        cards_rows = execute_query(
+            """
+            SELECT id, front, back, card_type,
+                   ease_factor, interval_days, next_review, review_count
+            FROM flashcards WHERE deck_id = %s ORDER BY id
+            """,
+            (str(deck_id),),
+        )
+
+        return FlashcardAllResponse(
+            id=deck_row["id"],
+            title=deck_row["title"],
+            tags=deck_row["tags"],
+            created_at=deck_row["created_at"],
+            cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to fetch flashcard deck")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch flashcard deck: {str(e)}",
+        )
+
+
+@router.put("/flashcards/{card_id}/progress", response_model=FlashcardResponse)
+async def update_flashcard_mastery(
+    card_id: UUID, review: FlashcardReviewRequest
+) -> FlashcardResponse:
+    """Apply one SM-2 review step to a single flashcard. quality 0-5."""
+    try:
+        card = execute_query(
+            """
+            SELECT id, ease_factor, interval_days, review_count
+            FROM flashcards WHERE id = %s
+            """,
+            (str(card_id),),
+            fetch_one=True,
+        )
+
+        if not card:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard not found"
+            )
+
+        q = review.quality
+        ef = float(card["ease_factor"])
+        interval = int(card["interval_days"])
+        review_count = int(card["review_count"])
+
+        # SM-2 algorithm
+        if q < 3:
+            interval = 0
+            review_count = 0
+        else:
+            if review_count == 0:
+                interval = 1
+            elif review_count == 1:
+                interval = 6
+            else:
+                interval = round(interval * ef)
+            review_count += 1
+
+        ef = max(1.3, ef + 0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+
+        updated = execute_query(
+            """
+            UPDATE flashcards
+            SET ease_factor   = %s,
+                interval_days = %s,
+                next_review   = NOW() + (%s || ' days')::interval,
+                review_count  = %s
+            WHERE id = %s
+            RETURNING id, front, back, card_type,
+                      ease_factor, interval_days, next_review, review_count
+            """,
+            (round(ef, 2), interval, interval, review_count, str(card_id)),
+            fetch_one=True,
+        )
+
+        return FlashcardResponse.model_validate(updated)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to update flashcard progress")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update flashcard progress: {str(e)}",
+        )
+
 
 @router.get("/flashcards", response_model=list[FlashcardAllResponse])
 async def get_all_flashcards() -> list[FlashcardAllResponse]:
-    pass
+    try:
+        decks = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks ORDER BY created_at DESC"
+        )
+
+        result = []
+        for deck in (decks or []):
+            cards_rows = execute_query(
+                """
+                SELECT id, front, back, card_type,
+                       ease_factor, interval_days, next_review, review_count
+                FROM flashcards WHERE deck_id = %s ORDER BY id
+                """,
+                (str(deck["id"]),),
+            )
+            result.append(FlashcardAllResponse(
+                id=deck["id"],
+                title=deck["title"],
+                tags=deck["tags"],
+                created_at=deck["created_at"],
+                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+            ))
+
+        return result
+
+    except Exception as e:
+        logger.exception("Failed to fetch flashcard decks")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch flashcard decks: {str(e)}",
+        )
+
 
 @router.delete("/flashcards/{deck_id}", response_model=FlashcardDeleteResponse)
 async def delete_flashcard_deck(deck_id: UUID) -> FlashcardDeleteResponse:
-    pass
+    try:
+        affected = execute_statement(
+            "DELETE FROM flashcard_decks WHERE id = %s", (str(deck_id),)
+        )
+
+        if affected == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard deck not found"
+            )
+
+        return FlashcardDeleteResponse(id=deck_id)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to delete flashcard deck")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete flashcard deck: {str(e)}",
+        )
+
 
 # -------- SUMMARY -------- #
 
+
 @router.post("/summary/generate", response_model=SummaryResponse)
-async def generate_summary(summary_info: SummaryGenerateRequest) -> SummaryResponse:
-    pass
+async def summary_generate(
+    summary_info: SummaryGenerateRequest, user=Depends(get_current_user)
+) -> SummaryResponse:
+    try:
+        generated = generate_summary(
+            piazza_course_id=summary_info.piazza_course_id,
+            title=summary_info.title,
+            summary_type=summary_info.summary_type,
+            source_posts=summary_info.source_posts,
+        )
+
+        row = execute_query(
+            """
+            INSERT INTO summaries (user_id, piazza_course_id, title, content, summary_type, source_posts)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id, title, content, summary_type,
+                      COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                      created_at
+            """,
+            (
+                str(user.id),
+                summary_info.piazza_course_id,
+                summary_info.title,
+                generated["content"],
+                summary_info.summary_type,
+                generated["source_posts"],
+            ),
+            fetch_one=True,
+        )
+
+        if not row:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to persist generated summary",
+            )
+
+        return SummaryResponse.model_validate(row)
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to generate summary")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate summary: {str(e)}",
+        )
+
 
 @router.get("/materials", response_model=AllStudyMaterialsResponse)
-async def list_all_study_materials() -> AllStudyMaterialsResponse:
-    pass
+async def list_all_study_materials(piazza_course_id: str) -> AllStudyMaterialsResponse:
+    try:
+        quiz_rows = execute_query(
+            """
+            SELECT id, title, difficulty, questions,
+                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                   created_at
+            FROM quizzes
+            WHERE piazza_course_id = %s
+            ORDER BY created_at DESC
+            """,
+            (piazza_course_id,),
+        )
+
+        deck_rows = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks WHERE piazza_course_id = %s ORDER BY created_at DESC",
+            (piazza_course_id,),
+        )
+
+        flashcard_decks = []
+        for deck in (deck_rows or []):
+            cards_rows = execute_query(
+                """
+                SELECT id, front, back, card_type,
+                       ease_factor, interval_days, next_review, review_count
+                FROM flashcards WHERE deck_id = %s ORDER BY id
+                """,
+                (str(deck["id"]),),
+            )
+            flashcard_decks.append(FlashcardAllResponse(
+                id=deck["id"],
+                title=deck["title"],
+                tags=deck["tags"],
+                created_at=deck["created_at"],
+                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+            ))
+
+        summary_rows = execute_query(
+            """
+            SELECT id, title, content, summary_type,
+                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                   created_at
+            FROM summaries
+            WHERE piazza_course_id = %s
+            ORDER BY created_at DESC
+            """,
+            (piazza_course_id,),
+        )
+
+        return AllStudyMaterialsResponse(
+            quizzes=[QuizResponse.model_validate(q) for q in (quiz_rows or [])],
+            flashcard_decks=flashcard_decks,
+            summaries=[SummaryResponse.model_validate(s) for s in (summary_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to fetch all study materials")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch study materials: {str(e)}",
+        )

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -18,7 +18,6 @@ class MessageResponse(BaseModel):
     message: str
     status: str
 
-api_router.include_router(study_materials.router, prefix="/study", tags=["study"])
 # Include example endpoints
 api_router.include_router(example.router, prefix="/example", tags=["users"])
 
@@ -37,6 +36,8 @@ api_router.include_router(chat_sessions.router, tags=["chat-sessions"])
 # Include document endpoints
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 
+# Include study material generator endpoints
+api_router.include_router(study_materials.router, prefix="/study", tags=["study-materials"])
 
 @api_router.get("/health", response_model=MessageResponse)
 def health_check():

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -47,6 +47,11 @@ class QuizDeleteResponse(BaseModel):
 
 # ------ Flashcards ------ #
 
+class FlashcardCard(BaseModel):
+    front: str
+    back: str
+    card_type: Literal["concept", "definition", "qa"]
+
 class FlashcardRequestGenerate(BaseModel):
     piazza_course_id: str
     title: str = Field(..., min_length=1, max_length=255)

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -15,7 +15,7 @@ class QuizGenerateRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     difficulty: Literal['easy', 'medium', 'hard']
     num_questions: int = Field(default=10, ge=1, le=50)
-    source_posts: Optional[list[str]]
+    source_posts: Optional[list[str]] = None
 
 
 class QuizSubmitRequest(BaseModel):

--- a/backend/app/textGeneration/__init__.py
+++ b/backend/app/textGeneration/__init__.py
@@ -3,6 +3,6 @@ Text Generation Module
 """
 
 from app.textGeneration.llm_service import get_llm_response, stream_llm_response
-from app.textGeneration.study_generator import generate_quiz_questions
+from app.textGeneration.study_generator import generate_quiz_questions, generate_flashcard_stream, generate_summary
 
-__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions"]
+__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions", "generate_flashcard_stream", "generate_summary"]

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -141,7 +141,7 @@ def generate_quiz_questions(
     chunks = _get_answered_chunks(
         piazza_course_id=piazza_course_id,
         source_posts=source_posts,
-        limit=max(num_questions * 6, 20),
+        limit=min(num_questions * 3, 30),
     )
     if not chunks:
         raise ValueError(
@@ -175,6 +175,9 @@ Rules:
 - 4 options per question.
 - Difficulty level: {difficulty}.
 - Quiz title: {title}.
+- Focus exclusively on course concepts, definitions, algorithms, theories, and technical subject matter.
+- NEVER generate questions about: grade curves or curve amounts, score adjustments or extra credit, exam/assignment score averages or statistics, grading scales or cutoffs, rounding policies, late penalties or extensions, exam logistics (time, location, format, duration), regrade or grading dispute discussions, or any other administrative/logistical announcements.
+- If a piece of context only contains administrative or grade-related information and no educational content, skip it entirely and draw from other context.
 """,
             ),
             ("human", "Context:\n{context}"),
@@ -210,6 +213,7 @@ Rules:
         "source_posts": resolved_source_posts,
         "model": QUIZ_MODEL,
     }
+
 
 
 def generate_summary(
@@ -277,6 +281,7 @@ Write a clear, well-structured prose summary. Do not return JSON.
 Summary type: {summary_type}
 Instructions: {type_instruction}
 Title: {title}
+Focus only on course content and educational material. Ignore posts about grades, exam logistics, grading disputes, assignment deadlines, or software/homework bugs unrelated to learning.
 """,
             ),
             ("human", "Context:\n{context}"),
@@ -351,6 +356,9 @@ Rules:
 - front: a concise question or term.
 - back: a clear, complete answer or explanation.
 - Deck title: {title}.
+- Focus exclusively on course concepts, definitions, algorithms, theories, and technical subject matter.
+- NEVER create flashcards about: grade curves or curve amounts, score adjustments or extra credit, exam/assignment score averages or statistics, grading scales or cutoffs, rounding policies, late penalties or extensions, exam logistics (time, location, format, duration), regrade or grading dispute discussions, or any other administrative/logistical announcements.
+- If a piece of context only contains administrative or grade-related information and no educational content, skip it entirely and draw from other context.
 {tags_instruction}""",
             ),
             ("human", "Context:\n{context}"),

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -8,12 +8,13 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_groq import ChatGroq
 
 from app.core.database import execute_query
-from app.models.study_materials import QuizQuestion
+from app.models.study_materials import FlashcardCard, QuizQuestion
 
 logger = logging.getLogger(__name__)
 
 QUIZ_MODEL = "openai/gpt-oss-120b"
 
+# ----------------------------- Quiz ------------------------------- #
 
 class QuizGenerationPayload(BaseModel):
     questions: list[QuizQuestion]
@@ -21,6 +22,16 @@ class QuizGenerationPayload(BaseModel):
 
 _quiz_payload_adapter = TypeAdapter(QuizGenerationPayload)
 _questions_schema_json = json.dumps(_quiz_payload_adapter.json_schema(), indent=2)
+
+
+# ----------------------------- Flashcards ------------------------------- #
+
+class FlashcardGenerationPayload(BaseModel):
+    cards: list[FlashcardCard]
+
+
+_flashcard_payload_adapter = TypeAdapter(FlashcardGenerationPayload)
+_flashcard_schema_json = json.dumps(_flashcard_payload_adapter.json_schema(), indent=2)
 
 
 def _extract_json_object(raw: str) -> dict[str, Any]:
@@ -196,6 +207,180 @@ Rules:
 
     return {
         "questions": [q.model_dump() for q in questions],
+        "source_posts": resolved_source_posts,
+        "model": QUIZ_MODEL,
+    }
+
+
+def generate_summary(
+    *,
+    piazza_course_id: str,
+    title: str,
+    summary_type: str,
+    source_posts: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """
+    Generate a prose summary from ingested answered posts.
+
+    Returns:
+        {
+            "content": str,
+            "source_posts": list[str],
+            "model": str
+        }
+    """
+    chunks = _get_answered_chunks(
+        piazza_course_id=piazza_course_id,
+        source_posts=source_posts,
+        limit=30,
+    )
+    if not chunks:
+        raise ValueError(
+            "No answered ingested posts found for this course. Run ingestion first."
+        )
+
+    context, resolved_source_posts = _build_context(chunks)
+
+    type_instructions = {
+        "thread": (
+            "Summarize the specific thread(s) provided. "
+            "Use a concise Q&A format: state the question(s) raised and the key answer(s) given."
+        ),
+        "weekly": (
+            "Write a weekly digest of all activity. "
+            "Organize by topic/theme. Briefly describe the main questions and resolutions."
+        ),
+        "exam_guide": (
+            "Create an exam study guide. "
+            "List key concepts, important definitions, and common question patterns found in the posts."
+        ),
+        "custom": (
+            "Write a comprehensive summary of the provided content. "
+            "Cover all major topics and important points."
+        ),
+    }
+    type_instruction = type_instructions.get(summary_type, type_instructions["custom"])
+
+    llm = ChatGroq(
+        model=QUIZ_MODEL,
+        temperature=0.3,
+        max_tokens=4000,
+        max_retries=3,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are summarizing Piazza course discussion posts for students.
+Write a clear, well-structured prose summary. Do not return JSON.
+Summary type: {summary_type}
+Instructions: {type_instruction}
+Title: {title}
+""",
+            ),
+            ("human", "Context:\n{context}"),
+        ]
+    )
+
+    content = (prompt | llm | StrOutputParser()).invoke(
+        {
+            "summary_type": summary_type,
+            "type_instruction": type_instruction,
+            "title": title,
+            "context": context,
+        }
+    )
+
+    if not content or not content.strip():
+        raise ValueError("LLM returned an empty summary.")
+
+    return {
+        "content": content.strip(),
+        "source_posts": resolved_source_posts,
+        "model": QUIZ_MODEL,
+    }
+
+
+def generate_flashcard_stream(
+    piazza_course_id: str,
+    title: str,
+    tags: Optional[list[str]],
+    source_posts: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """
+    Generate flashcards from ingested answered posts.
+
+    Returns:
+        {
+            "cards": list[dict],
+            "source_posts": list[str],
+            "model": str
+        }
+    """
+    chunks = _get_answered_chunks(piazza_course_id, source_posts, 20)
+
+    if not chunks:
+        raise ValueError(
+            "No answered ingested posts found for this course. Run ingestion first."
+        )
+
+    context, resolved_source_posts = _build_context(chunks)
+
+    llm = ChatGroq(
+        model=QUIZ_MODEL,
+        temperature=0.2,
+        max_tokens=6000,
+        max_retries=3,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are generating course flashcards from Piazza context.
+Return strict JSON only. No markdown, no prose.
+Your output must conform to this Pydantic JSON schema (for `cards` only):
+{flashcard_schema}
+Output envelope must be:
+{{"cards": [...]}}
+Rules:
+- Generate between 10 and 20 flashcards depending on available context.
+- Each card must be grounded in the provided context.
+- card_type must be one of: "concept", "definition", "qa".
+- front: a concise question or term.
+- back: a clear, complete answer or explanation.
+- Deck title: {title}.
+{tags_instruction}""",
+            ),
+            ("human", "Context:\n{context}"),
+        ]
+    )
+
+    tags_instruction = (
+        f"- Focus on these topic tags: {', '.join(tags)}." if tags else ""
+    )
+
+    raw = (prompt | llm | StrOutputParser()).invoke(
+        {
+            "flashcard_schema": _flashcard_schema_json,
+            "title": title,
+            "tags_instruction": tags_instruction,
+            "context": context,
+        }
+    )
+
+    parsed = _extract_json_object(raw)
+
+    try:
+        payload = _flashcard_payload_adapter.validate_python(parsed)
+        cards = payload.cards
+    except ValidationError as e:
+        logger.error("Flashcard validation failed: %s", e)
+        raise ValueError("Generated flashcard format is invalid.")
+
+    return {
+        "cards": [c.model_dump() for c in cards],
         "source_posts": resolved_source_posts,
         "model": QUIZ_MODEL,
     }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -32,5 +32,11 @@
     "service_worker": "background.js"
   },
   "permissions": ["activeTab", "storage", "cookies"],
-  "host_permissions": ["https://piazza.com/*", "http://localhost:8000/*"]
+  "host_permissions": ["https://piazza.com/*", "http://localhost:8000/*"],
+  "web_accessible_resources": [
+    {
+      "resources": ["studytab.html"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/frontend/src/popup/App.jsx
+++ b/frontend/src/popup/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import LoginPage from "./LoginPage";
 import DashboardPage from "./DashboardPage";
 import AssistantPage from "./AssistantPage";
+import StudyMaterialsPage from "./StudyMaterialsPage";
 
 /* global chrome */
 export default function App() {
@@ -175,9 +176,16 @@ export default function App() {
             user={user}
             onLogout={handleLogout}
             onNavigateToAssistant={() => setCurrentPage("assistant")}
+            onNavigateToStudy={() => setCurrentPage("study")}
+          />
+        ) : currentPage === "assistant" ? (
+          <AssistantPage
+            user={user}
+            onBack={() => setCurrentPage("dashboard")}
+            onLogout={handleLogout}
           />
         ) : (
-          <AssistantPage
+          <StudyMaterialsPage
             user={user}
             onBack={() => setCurrentPage("dashboard")}
             onLogout={handleLogout}

--- a/frontend/src/popup/App.jsx
+++ b/frontend/src/popup/App.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import LoginPage from "./LoginPage";
 import DashboardPage from "./DashboardPage";
 import AssistantPage from "./AssistantPage";
-import StudyMaterialsPage from "./StudyMaterialsPage";
 
 /* global chrome */
 export default function App() {
@@ -176,16 +175,9 @@ export default function App() {
             user={user}
             onLogout={handleLogout}
             onNavigateToAssistant={() => setCurrentPage("assistant")}
-            onNavigateToStudy={() => setCurrentPage("study")}
-          />
-        ) : currentPage === "assistant" ? (
-          <AssistantPage
-            user={user}
-            onBack={() => setCurrentPage("dashboard")}
-            onLogout={handleLogout}
           />
         ) : (
-          <StudyMaterialsPage
+          <AssistantPage
             user={user}
             onBack={() => setCurrentPage("dashboard")}
             onLogout={handleLogout}

--- a/frontend/src/popup/DashboardPage.jsx
+++ b/frontend/src/popup/DashboardPage.jsx
@@ -37,7 +37,6 @@ export default function DashboardPage({
   user,
   onLogout,
   onNavigateToAssistant,
-  onNavigateToStudy,
 }) {
   const [currentTab, setCurrentTab] = useState(null);
   const [piazzaInfo, setPiazzaInfo] = useState(null);
@@ -357,7 +356,12 @@ export default function DashboardPage({
                   Assistant
                 </button>
                 <button
-                  onClick={onNavigateToStudy}
+                  onClick={() => {
+                    const url = new URL(chrome.runtime.getURL("studytab.html"));
+                    if (piazzaInfo?.classId)
+                      url.searchParams.set("course_id", piazzaInfo.classId);
+                    chrome.tabs.create({ url: url.toString() });
+                  }}
                   className="flex-1 px-3 py-2 bg-gray-100 border border-gray-200 rounded-md text-xs font-medium cursor-pointer flex items-center justify-center gap-1.5 transition-all hover:bg-gray-200 hover:border-gray-300"
                 >
                   <span>📚</span>

--- a/frontend/src/popup/DashboardPage.jsx
+++ b/frontend/src/popup/DashboardPage.jsx
@@ -37,6 +37,7 @@ export default function DashboardPage({
   user,
   onLogout,
   onNavigateToAssistant,
+  onNavigateToStudy,
 }) {
   const [currentTab, setCurrentTab] = useState(null);
   const [piazzaInfo, setPiazzaInfo] = useState(null);
@@ -137,7 +138,7 @@ export default function DashboardPage({
           isPiazza: true,
           fullUrl: tab.url,
           classId: pathParts[1] || null,
-          postId: url.searchParams.get("cid") || null,
+          postId: pathParts[2] === "post" ? pathParts[3] || null : null,
           pathname: url.pathname,
           threadName: null,
         };
@@ -354,6 +355,13 @@ export default function DashboardPage({
                 >
                   <span>📊</span>
                   Assistant
+                </button>
+                <button
+                  onClick={onNavigateToStudy}
+                  className="flex-1 px-3 py-2 bg-gray-100 border border-gray-200 rounded-md text-xs font-medium cursor-pointer flex items-center justify-center gap-1.5 transition-all hover:bg-gray-200 hover:border-gray-300"
+                >
+                  <span>📚</span>
+                  Study Materials
                 </button>
                 <button
                   onClick={handleIngestThread}

--- a/frontend/src/popup/StudyMaterialsPage.jsx
+++ b/frontend/src/popup/StudyMaterialsPage.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+
+/* global chrome */
+const API_ENDPOINT = process.env.API_ENDPOINT || "http://localhost:8000/api/v1";
+
+export default function StudyMaterialsPage({ user, onBack, onLogout }) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [results, setResults] = useState(null); // { quiz, flashcards, summary }
+
+  useEffect(() => {
+    generateAll();
+  }, []);
+
+  const generateAll = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    // Detect Piazza class ID from active tab
+    let piazza_course_id;
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tab && tab.url && tab.url.includes("piazza.com")) {
+        const url = new URL(tab.url);
+        const pathParts = url.pathname.split("/").filter(Boolean);
+        piazza_course_id = pathParts[1];
+      }
+    } catch (err) {
+      console.error("Error reading tab info:", err);
+    }
+
+    if (!piazza_course_id) {
+      setError("No Piazza course detected. Navigate to a Piazza class page first.");
+      setIsLoading(false);
+      return;
+    }
+
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${user.access_token}`,
+    };
+
+    try {
+      const [quizRes, flashcardsRes, summaryRes] = await Promise.all([
+        fetch(`${API_ENDPOINT}/study/quiz/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Quiz",
+            difficulty: "medium",
+            num_questions: 5,
+          }),
+        }),
+        fetch(`${API_ENDPOINT}/study/flashcards/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Flashcards",
+          }),
+        }),
+        fetch(`${API_ENDPOINT}/study/summary/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Summary",
+            summary_type: "weekly",
+          }),
+        }),
+      ]);
+
+      // Handle 401 on any call
+      if (
+        quizRes.status === 401 ||
+        flashcardsRes.status === 401 ||
+        summaryRes.status === 401
+      ) {
+        onLogout();
+        return;
+      }
+
+      const [quiz, flashcards, summary] = await Promise.all([
+        quizRes.json(),
+        flashcardsRes.json(),
+        summaryRes.json(),
+      ]);
+
+      setResults({ quiz, flashcards, summary });
+    } catch (err) {
+      setError(`Failed to generate study materials: ${err.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-[500px]">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-purple-500 to-purple-700 p-5 flex items-center gap-3 text-white">
+        <button
+          onClick={onBack}
+          className="bg-white/20 border-none text-white w-8 h-8 rounded-md cursor-pointer text-base flex items-center justify-center transition-colors hover:bg-white/30"
+          title="Back"
+        >
+          ←
+        </button>
+        <div className="flex-1">
+          <h2 className="text-base font-semibold m-0">Study Materials</h2>
+          <p className="text-xs m-0 mt-0.5 opacity-90">{user.name}</p>
+        </div>
+        <button
+          onClick={onLogout}
+          className="bg-white/20 border-none text-white px-3 py-1.5 rounded-md cursor-pointer text-xs transition-colors hover:bg-white/30"
+        >
+          Logout
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center flex-1 gap-4 py-16">
+            <div className="w-10 h-10 border-3 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
+            <p className="text-gray-600 text-sm">Generating study materials…</p>
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {results && !isLoading && (
+          <>
+            <Section title="Quiz" data={results.quiz} />
+            <Section title="Flashcards" data={results.flashcards} />
+            <Section title="Summary" data={results.summary} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, data }) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
+        <h3 className="text-sm font-semibold text-gray-800 m-0">{title}</h3>
+      </div>
+      <pre className="p-4 text-xs text-gray-700 overflow-x-auto whitespace-pre-wrap break-words m-0">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/popup/StudyMaterialsPage.jsx
+++ b/frontend/src/popup/StudyMaterialsPage.jsx
@@ -1,159 +1,1437 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 /* global chrome */
 const API_ENDPOINT = process.env.API_ENDPOINT || "http://localhost:8000/api/v1";
 
-export default function StudyMaterialsPage({ user, onBack, onLogout }) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [results, setResults] = useState(null); // { quiz, flashcards, summary }
+// Used in the top bar (includes Home)
+const TOP_NAV_ITEMS = [
+  { key: "home", label: "Home" },
+  { key: "quiz", label: "Quiz" },
+  { key: "flashcards", label: "Flashcards" },
+  { key: "summary", label: "Summary" },
+];
 
-  useEffect(() => {
-    generateAll();
-  }, []);
+// Used only for the homepage cards
+const SECTION_ITEMS = [
+  { key: "quiz", label: "Quiz", icon: "📝", desc: "Test your knowledge" },
+  { key: "flashcards", label: "Flashcards", icon: "🃏", desc: "Review key terms" },
+  { key: "summary", label: "Summary", icon: "📄", desc: "Quick overview" },
+];
 
-  const generateAll = async () => {
-    setIsLoading(true);
-    setError(null);
+const lightTheme = {
+  bg: "#ffffff",
+  cardBg: "#ffffff",
+  cardBgHover: "#f5f3ff",
+  text: "#111827",
+  textMuted: "#6b7280",
+  accent: "#7c3aed",
+  pillBg: "#7c3aed",
+  pillText: "#ffffff",
+  cardBorder: "#e5e7eb",
+  cardBorderHover: "#7c3aed",
+  spinnerTrack: "#e5e7eb",
+  spinnerFill: "#a855f7",
+};
 
-    // Detect Piazza class ID from active tab
-    let piazza_course_id;
+const darkTheme = {
+  bg: "#222831",
+  cardBg: "#393E46",
+  cardBgHover: "#454c57",
+  text: "#DFD0B8",
+  textMuted: "#948979",
+  accent: "#DFD0B8",
+  pillBg: "#DFD0B8",
+  pillText: "#222831",
+  cardBorder: "#505863",
+  cardBorderHover: "#948979",
+  spinnerTrack: "#505863",
+  spinnerFill: "#DFD0B8",
+};
+
+export default function StudyMaterialsPage({ user, onLogout, piazzaCourseId }) {
+  const [view, setView] = useState("home");
+  const [darkMode, setDarkMode] = useState(false);
+  const [loadingKey, setLoadingKey] = useState(null);
+  const [results, setResults] = useState({ quiz: null, flashcards: null, summary: null });
+  const [errors, setErrors] = useState({ quiz: null, flashcards: null, summary: null });
+  const [quizRetryKey, setQuizRetryKey] = useState(0);
+
+  const theme = darkMode ? darkTheme : lightTheme;
+
+  const resolveCourseId = async () => {
+    if (piazzaCourseId) return piazzaCourseId;
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (tab && tab.url && tab.url.includes("piazza.com")) {
-        const url = new URL(tab.url);
-        const pathParts = url.pathname.split("/").filter(Boolean);
-        piazza_course_id = pathParts[1];
+      if (tab?.url?.includes("piazza.com")) {
+        const pathParts = new URL(tab.url).pathname.split("/").filter(Boolean);
+        return pathParts[1] || null;
       }
     } catch (err) {
       console.error("Error reading tab info:", err);
     }
+    return null;
+  };
 
-    if (!piazza_course_id) {
-      setError("No Piazza course detected. Navigate to a Piazza class page first.");
-      setIsLoading(false);
+  const handleNavigate = async (key, force = false) => {
+    if (key === "home") {
+      setView("home");
       return;
     }
 
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${user.access_token}`,
-    };
+    setView(key);
+
+    // Already cached — no need to re-fetch
+    if (!force && results[key] !== null) return;
+
+    setLoadingKey(key);
 
     try {
-      const [quizRes, flashcardsRes, summaryRes] = await Promise.all([
-        fetch(`${API_ENDPOINT}/study/quiz/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Quiz",
-            difficulty: "medium",
-            num_questions: 5,
-          }),
-        }),
-        fetch(`${API_ENDPOINT}/study/flashcards/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Flashcards",
-          }),
-        }),
-        fetch(`${API_ENDPOINT}/study/summary/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Summary",
-            summary_type: "weekly",
-          }),
-        }),
-      ]);
-
-      // Handle 401 on any call
-      if (
-        quizRes.status === 401 ||
-        flashcardsRes.status === 401 ||
-        summaryRes.status === 401
-      ) {
-        onLogout();
+      const piazza_course_id = await resolveCourseId();
+      if (!piazza_course_id) {
+        setErrors(prev => ({ ...prev, [key]: "No Piazza course detected. Navigate to a Piazza class page first." }));
         return;
       }
 
-      const [quiz, flashcards, summary] = await Promise.all([
-        quizRes.json(),
-        flashcardsRes.json(),
-        summaryRes.json(),
-      ]);
+      const headers = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${user.access_token}`,
+      };
 
-      setResults({ quiz, flashcards, summary });
+      const configs = {
+        quiz: {
+          url: `${API_ENDPOINT}/study/quiz/generate`,
+          body: { piazza_course_id, title: "Auto Quiz", difficulty: "medium", num_questions: 7 },
+        },
+        flashcards: {
+          url: `${API_ENDPOINT}/study/flashcards/generate`,
+          body: { piazza_course_id, title: "Auto Flashcards" },
+        },
+        summary: {
+          url: `${API_ENDPOINT}/study/summary/generate`,
+          body: { piazza_course_id, title: "Auto Summary", summary_type: "weekly" },
+        },
+      };
+
+      const { url, body } = configs[key];
+      const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+      if (res.status === 401) { onLogout(); return; }
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = await res.json();
+      setResults(prev => ({ ...prev, [key]: data }));
     } catch (err) {
-      setError(`Failed to generate study materials: ${err.message}`);
+      setErrors(prev => ({ ...prev, [key]: err.message }));
     } finally {
-      setIsLoading(false);
+      setLoadingKey(null);
     }
   };
 
+  const showQuizView = view === "quiz" && results.quiz && loadingKey !== "quiz" && !errors.quiz;
+  const showFlashcardsView = view === "flashcards" && results.flashcards && loadingKey !== "flashcards" && !errors.flashcards;
+
   return (
-    <div className="flex flex-col min-h-[500px]">
-      {/* Header */}
-      <div className="bg-gradient-to-r from-purple-500 to-purple-700 p-5 flex items-center gap-3 text-white">
-        <button
-          onClick={onBack}
-          className="bg-white/20 border-none text-white w-8 h-8 rounded-md cursor-pointer text-base flex items-center justify-center transition-colors hover:bg-white/30"
-          title="Back"
-        >
-          ←
-        </button>
-        <div className="flex-1">
-          <h2 className="text-base font-semibold m-0">Study Materials</h2>
-          <p className="text-xs m-0 mt-0.5 opacity-90">{user.name}</p>
+    <div
+      style={{
+        backgroundColor: theme.bg,
+        color: theme.text,
+        minHeight: "100vh",
+        transition: "background-color 300ms ease, color 300ms ease",
+      }}
+      className="flex flex-col"
+    >
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-8 py-4">
+        <SlidingPillNav theme={theme} items={TOP_NAV_ITEMS} activeKey={view} onSelect={handleNavigate} />
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setDarkMode(d => !d)}
+            style={{ background: "none", border: "none", cursor: "pointer", fontSize: "20px", lineHeight: 1 }}
+            title={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {darkMode ? "☀️" : "🌙"}
+          </button>
+          <button
+            onClick={onLogout}
+            style={{
+              color: theme.textMuted,
+              backgroundColor: "transparent",
+              border: `1px solid ${theme.cardBorder}`,
+              borderRadius: "6px",
+              padding: "5px 14px",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontWeight: "500",
+            }}
+          >
+            Logout
+          </button>
         </div>
+      </div>
+
+      {view === "home" ? (
+        <HomePage theme={theme} onNavigate={handleNavigate} />
+      ) : showQuizView ? (
+        <QuizView
+          key={quizRetryKey}
+          theme={theme}
+          quizData={results.quiz}
+          user={user}
+          onRetry={() => setQuizRetryKey(k => k + 1)}
+          onNewQuiz={() => {
+            setResults(prev => ({ ...prev, quiz: null }));
+            setErrors(prev => ({ ...prev, quiz: null }));
+            handleNavigate("quiz", true);
+          }}
+        />
+      ) : showFlashcardsView ? (
+        <FlashcardsView
+          theme={theme}
+          flashcardData={results.flashcards}
+          user={user}
+          onNewDeck={() => {
+            setResults(prev => ({ ...prev, flashcards: null }));
+            setErrors(prev => ({ ...prev, flashcards: null }));
+            handleNavigate("flashcards", true);
+          }}
+        />
+      ) : (
+        <SectionView
+          theme={theme}
+          view={view}
+          isLoading={loadingKey === view}
+          result={results[view]}
+          error={errors[view]}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Quiz Components ──────────────────────────────────────────────────────────
+
+function QuizView({ theme, quizData, user, onRetry, onNewQuiz }) {
+  const { questions, id, title, difficulty } = quizData;
+
+  const [mcAnswers, setMcAnswers] = useState({});
+  const [msSelections, setMsSelections] = useState({});
+  const [msAnswers, setMsAnswers] = useState({});
+  const [lockedQuestions, setLockedQuestions] = useState(new Set());
+  const [revealCorrect, setRevealCorrect] = useState(new Set());
+  const [phase, setPhase] = useState("taking");
+  const [quizResult, setQuizResult] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const allAnswered = questions.every((_, i) => lockedQuestions.has(i));
+
+  const handleMCAnswer = (qIdx, selectedOption) => {
+    if (lockedQuestions.has(qIdx)) return;
+    const correct = questions[qIdx].correct_answer;
+    setMcAnswers(prev => ({ ...prev, [qIdx]: selectedOption }));
+    setLockedQuestions(prev => new Set([...prev, qIdx]));
+    if (selectedOption !== correct) {
+      setTimeout(() => {
+        setRevealCorrect(prev => new Set([...prev, qIdx]));
+      }, 800);
+    } else {
+      setRevealCorrect(prev => new Set([...prev, qIdx]));
+    }
+  };
+
+  const handleMSToggle = (qIdx, option) => {
+    if (lockedQuestions.has(qIdx)) return;
+    setMsSelections(prev => {
+      const current = prev[qIdx] || [];
+      if (current.includes(option)) {
+        return { ...prev, [qIdx]: current.filter(o => o !== option) };
+      }
+      return { ...prev, [qIdx]: [...current, option] };
+    });
+  };
+
+  const handleMSSubmit = (qIdx) => {
+    if (lockedQuestions.has(qIdx)) return;
+    const selected = msSelections[qIdx] || [];
+    setMsAnswers(prev => ({ ...prev, [qIdx]: selected }));
+    setLockedQuestions(prev => new Set([...prev, qIdx]));
+    setRevealCorrect(prev => new Set([...prev, qIdx]));
+  };
+
+  const handleFinishQuiz = async () => {
+    setIsSubmitting(true);
+    const answersArray = questions.map((q, i) =>
+      q.type === "multiple_select" ? (msAnswers[i] || []) : (mcAnswers[i] || "")
+    );
+    try {
+      const res = await fetch(`${API_ENDPOINT}/study/quiz/${id}/submit`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${user.access_token}`,
+        },
+        body: JSON.stringify({ answers: answersArray }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setQuizResult(data);
+      }
+    } catch (err) {
+      console.error("Quiz submit failed:", err);
+    } finally {
+      setIsSubmitting(false);
+      setPhase("results");
+    }
+  };
+
+  if (phase === "results") {
+    return (
+      <QuizResults
+        theme={theme}
+        result={quizResult}
+        totalCount={questions.length}
+        onRetry={onRetry}
+        onNewQuiz={onNewQuiz}
+      />
+    );
+  }
+
+  const difficultyColors = {
+    easy: { bg: "#dcfce7", text: "#15803d", border: "#86efac" },
+    medium: { bg: "#fef9c3", text: "#a16207", border: "#fde047" },
+    hard: { bg: "#fee2e2", text: "#b91c1c", border: "#fca5a5" },
+  };
+  const diffColor = difficultyColors[difficulty] || difficultyColors.medium;
+  const accentText = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  return (
+    <div className="flex flex-col flex-1" style={{ paddingBottom: "80px" }}>
+      {/* Quiz header */}
+      <div style={{ padding: "0 32px 20px", maxWidth: "760px", width: "100%", margin: "0 auto" }}>
+        <div className="flex items-center gap-3" style={{ marginBottom: "4px" }}>
+          <h2 style={{ margin: 0, fontSize: "20px", fontWeight: "700", color: theme.text }}>
+            {title}
+          </h2>
+          <span
+            style={{
+              backgroundColor: diffColor.bg,
+              color: diffColor.text,
+              border: `1px solid ${diffColor.border}`,
+              borderRadius: "9999px",
+              padding: "2px 10px",
+              fontSize: "11px",
+              fontWeight: "600",
+              textTransform: "capitalize",
+            }}
+          >
+            {difficulty}
+          </span>
+        </div>
+        <p style={{ margin: 0, fontSize: "13px", color: theme.textMuted }}>
+          {questions.length} questions — answer all to finish
+        </p>
+      </div>
+
+      {/* Questions list */}
+      <div
+        style={{
+          maxWidth: "760px",
+          width: "100%",
+          margin: "0 auto",
+          padding: "0 32px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "20px",
+        }}
+      >
+        {questions.map((q, qIdx) => {
+          const isLocked = lockedQuestions.has(qIdx);
+          const isRevealed = revealCorrect.has(qIdx);
+          const isMS = q.type === "multiple_select";
+          const msSelected = msSelections[qIdx] || [];
+          const msLocked = msAnswers[qIdx] || [];
+          const correctAnswers = Array.isArray(q.correct_answer)
+            ? q.correct_answer
+            : [q.correct_answer];
+
+          return (
+            <div
+              key={qIdx}
+              style={{
+                backgroundColor: theme.cardBg,
+                border: `1px solid ${isLocked && isRevealed ? theme.cardBorder : theme.cardBorder}`,
+                borderRadius: "12px",
+                padding: "20px",
+                transition: "border-color 200ms ease",
+              }}
+            >
+              {/* Question number + text */}
+              <div className="flex items-start gap-3" style={{ marginBottom: "14px" }}>
+                <span
+                  style={{
+                    minWidth: "26px",
+                    height: "26px",
+                    borderRadius: "50%",
+                    backgroundColor: isLocked
+                      ? (isRevealed ? "#dcfce7" : "#fee2e2")
+                      : theme.accent,
+                    color: isLocked
+                      ? (isRevealed ? "#15803d" : "#b91c1c")
+                      : accentText,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "12px",
+                    fontWeight: "700",
+                    flexShrink: 0,
+                    transition: "background-color 400ms ease, color 400ms ease",
+                  }}
+                >
+                  {qIdx + 1}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <p style={{ margin: 0, fontSize: "14px", fontWeight: "600", color: theme.text, lineHeight: "1.55" }}>
+                    {q.question}
+                  </p>
+                  {isMS && (
+                    <span style={{ fontSize: "11px", color: theme.textMuted, marginTop: "4px", display: "block" }}>
+                      Select all that apply
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Options */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "8px", paddingLeft: "38px" }}>
+                {q.options.map((option, oIdx) => {
+                  if (isMS) {
+                    const isChecked = isLocked ? msLocked.includes(option) : msSelected.includes(option);
+                    const isCorrectOpt = correctAnswers.includes(option);
+
+                    let optBg = theme.cardBg;
+                    let optBorder = theme.cardBorder;
+                    let optColor = theme.text;
+                    let optOpacity = 1;
+
+                    if (isLocked) {
+                      if (isChecked && isCorrectOpt) {
+                        optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                      } else if (isChecked && !isCorrectOpt) {
+                        optBg = "#fee2e2"; optBorder = "#dc2626"; optColor = "#b91c1c";
+                      } else if (!isChecked && isCorrectOpt) {
+                        optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                      } else {
+                        optOpacity = 0.5;
+                      }
+                    }
+
+                    const checkBorderColor = isLocked
+                      ? optBorder
+                      : (isChecked ? theme.accent : theme.cardBorder);
+                    const checkBg = isChecked ? (isLocked ? optBorder : theme.accent) : "transparent";
+
+                    return (
+                      <button
+                        key={oIdx}
+                        onClick={() => handleMSToggle(qIdx, option)}
+                        disabled={isLocked}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "10px",
+                          width: "100%",
+                          padding: "10px 14px",
+                          borderRadius: "8px",
+                          border: `1.5px solid ${optBorder}`,
+                          backgroundColor: optBg,
+                          color: optColor,
+                          cursor: isLocked ? "default" : "pointer",
+                          textAlign: "left",
+                          fontFamily: "inherit",
+                          opacity: optOpacity,
+                          transition: "all 200ms ease",
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: "16px",
+                            height: "16px",
+                            borderRadius: "4px",
+                            border: `2px solid ${checkBorderColor}`,
+                            backgroundColor: checkBg,
+                            flexShrink: 0,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            transition: "all 150ms ease",
+                          }}
+                        >
+                          {isChecked && (
+                            <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                              <path
+                                d="M1 4L3.5 6.5L9 1"
+                                stroke="#fff"
+                                strokeWidth="1.8"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          )}
+                        </span>
+                        <span style={{ fontSize: "13px", fontWeight: "500" }}>{option}</span>
+                      </button>
+                    );
+                  }
+
+                  // Multiple choice
+                  const userAnswer = mcAnswers[qIdx];
+                  const isSelected = option === userAnswer;
+                  const isCorrectOpt = option === q.correct_answer;
+
+                  let optBg = theme.cardBg;
+                  let optBorder = theme.cardBorder;
+                  let optColor = theme.text;
+                  let optOpacity = 1;
+
+                  if (isLocked) {
+                    if (isSelected && isCorrectOpt) {
+                      optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                    } else if (isSelected && !isCorrectOpt) {
+                      optBg = "#fee2e2"; optBorder = "#dc2626"; optColor = "#b91c1c";
+                    } else if (!isSelected && isCorrectOpt && isRevealed) {
+                      optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                    } else {
+                      optOpacity = 0.5;
+                    }
+                  }
+
+                  return (
+                    <button
+                      key={oIdx}
+                      onClick={() => handleMCAnswer(qIdx, option)}
+                      disabled={isLocked}
+                      style={{
+                        width: "100%",
+                        padding: "10px 14px",
+                        borderRadius: "8px",
+                        border: `1.5px solid ${optBorder}`,
+                        backgroundColor: optBg,
+                        color: optColor,
+                        cursor: isLocked ? "default" : "pointer",
+                        textAlign: "left",
+                        fontFamily: "inherit",
+                        opacity: optOpacity,
+                        transition: "all 200ms ease",
+                      }}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: "500" }}>{option}</span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* MS per-question submit button */}
+              {isMS && !isLocked && (
+                <div style={{ paddingLeft: "38px", marginTop: "12px" }}>
+                  <button
+                    onClick={() => handleMSSubmit(qIdx)}
+                    disabled={msSelected.length === 0}
+                    style={{
+                      backgroundColor: msSelected.length === 0 ? theme.cardBorder : theme.accent,
+                      color: msSelected.length === 0 ? theme.textMuted : accentText,
+                      border: "none",
+                      borderRadius: "8px",
+                      padding: "8px 18px",
+                      fontSize: "12px",
+                      fontWeight: "600",
+                      cursor: msSelected.length === 0 ? "not-allowed" : "pointer",
+                      transition: "all 150ms ease",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    Submit Answer
+                  </button>
+                </div>
+              )}
+
+              {/* Explanation shown after answering */}
+              {isLocked && isRevealed && q.explanation && (
+                <div style={{ paddingLeft: "38px", marginTop: "12px" }}>
+                  <div
+                    style={{
+                      backgroundColor: theme.cardBgHover,
+                      borderRadius: "8px",
+                      padding: "10px 14px",
+                      fontSize: "12px",
+                      color: theme.textMuted,
+                      lineHeight: "1.6",
+                    }}
+                  >
+                    <span style={{ fontWeight: "600", color: theme.accent }}>Explanation: </span>
+                    {q.explanation}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Sticky bottom bar with Finish Quiz button */}
+      <div
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          backgroundColor: theme.bg,
+          borderTop: `1px solid ${theme.cardBorder}`,
+          padding: "12px 32px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          zIndex: 10,
+        }}
+      >
+        <span style={{ fontSize: "13px", color: theme.textMuted }}>
+          {lockedQuestions.size} / {questions.length} answered
+        </span>
         <button
-          onClick={onLogout}
-          className="bg-white/20 border-none text-white px-3 py-1.5 rounded-md cursor-pointer text-xs transition-colors hover:bg-white/30"
+          onClick={handleFinishQuiz}
+          disabled={!allAnswered || isSubmitting}
+          style={{
+            backgroundColor: allAnswered ? theme.accent : theme.cardBorder,
+            color: allAnswered ? accentText : theme.textMuted,
+            border: "none",
+            borderRadius: "8px",
+            padding: "10px 24px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: allAnswered && !isSubmitting ? "pointer" : "not-allowed",
+            transition: "all 150ms ease",
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            fontFamily: "inherit",
+          }}
         >
-          Logout
+          {isSubmitting ? (
+            <>
+              <span
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  borderRadius: "50%",
+                  border: "2px solid rgba(255,255,255,0.35)",
+                  borderTopColor: "#fff",
+                  display: "inline-block",
+                  animation: "spin 0.6s linear infinite",
+                }}
+              />
+              Submitting…
+            </>
+          ) : (
+            "Finish Quiz"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function QuizResults({ theme, result, totalCount, onRetry, onNewQuiz }) {
+  const score = result ? result.score : null;
+  const correctCount = result ? result.correct_count : 0;
+  const total = result ? result.total_count : totalCount;
+  const accentText = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  let emoji, message;
+  if (score === null) {
+    emoji = "📊"; message = "Quiz complete!";
+  } else if (score >= 80) {
+    emoji = "🎉"; message = "Great job!";
+  } else if (score >= 60) {
+    emoji = "👍"; message = "Good effort!";
+  } else {
+    emoji = "📖"; message = "Keep practicing!";
+  }
+
+  const scoreColor = score === null ? theme.accent
+    : score >= 80 ? "#16a34a"
+    : score >= 60 ? "#d97706"
+    : "#dc2626";
+
+  return (
+    <div
+      className="flex flex-col flex-1 items-center justify-center"
+      style={{ padding: "40px 32px" }}
+    >
+      <div
+        style={{
+          backgroundColor: theme.cardBg,
+          border: `1px solid ${theme.cardBorder}`,
+          borderRadius: "20px",
+          padding: "48px 56px",
+          maxWidth: "420px",
+          width: "100%",
+          textAlign: "center",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "12px" }}>{emoji}</div>
+        <h2 style={{ margin: "0 0 8px", fontSize: "22px", fontWeight: "800", color: theme.text }}>
+          {message}
+        </h2>
+
+        {score !== null ? (
+          <>
+            <div
+              style={{
+                fontSize: "60px",
+                fontWeight: "800",
+                color: scoreColor,
+                lineHeight: 1,
+                margin: "20px 0 8px",
+              }}
+            >
+              {score}%
+            </div>
+            <p style={{ margin: "0 0 24px", fontSize: "15px", color: theme.textMuted }}>
+              {correctCount} / {total} correct
+            </p>
+            {/* Progress bar */}
+            <div
+              style={{
+                height: "8px",
+                borderRadius: "9999px",
+                backgroundColor: theme.cardBorder,
+                overflow: "hidden",
+                marginBottom: "32px",
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${score}%`,
+                  borderRadius: "9999px",
+                  backgroundColor: scoreColor,
+                  transition: "width 600ms ease",
+                }}
+              />
+            </div>
+          </>
+        ) : (
+          <p style={{ margin: "0 0 32px", fontSize: "14px", color: theme.textMuted }}>
+            {correctCount} / {total} answered
+          </p>
+        )}
+
+        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
+          <button
+            onClick={onRetry}
+            style={{
+              backgroundColor: "transparent",
+              color: theme.text,
+              border: `1.5px solid ${theme.cardBorder}`,
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            Try Again
+          </button>
+          <button
+            onClick={onNewQuiz}
+            style={{
+              backgroundColor: theme.accent,
+              color: accentText,
+              border: "none",
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            New Quiz
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Flashcard Components ─────────────────────────────────────────────────────
+
+const CARD_TYPE_STYLES = {
+  concept:    { bg: "#ede9fe", text: "#7c3aed", border: "#c4b5fd", label: "Concept"    },
+  definition: { bg: "#dcfce7", text: "#16a34a", border: "#86efac", label: "Definition" },
+  qa:         { bg: "#fff7ed", text: "#c2410c", border: "#fdba74", label: "Q & A"      },
+};
+
+function FlashcardsView({ theme, flashcardData, user, onNewDeck }) {
+  const { cards, title } = flashcardData;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isFlipped, setIsFlipped]       = useState(false);
+  const [ratings, setRatings]           = useState({});
+  const [isRating, setIsRating]         = useState(false);
+  const [sessionPhase, setSessionPhase] = useState("active");
+
+  const card       = cards[currentIndex];
+  const totalCards = cards.length;
+  const typeStyle  = CARD_TYPE_STYLES[card.card_type] || CARD_TYPE_STYLES.concept;
+  const isRated    = ratings[card.id] !== undefined;
+
+  const handlePrev = () => {
+    if (currentIndex === 0) return;
+    setIsFlipped(false);
+    setCurrentIndex(i => i - 1);
+  };
+
+  const handleNext = () => {
+    if (currentIndex === totalCards - 1) return;
+    setIsFlipped(false);
+    setCurrentIndex(i => i + 1);
+  };
+
+  const handleRate = async (quality) => {
+    if (isRating) return;
+    setIsRating(true);
+    setRatings(prev => ({ ...prev, [card.id]: quality }));
+
+    try {
+      await fetch(`${API_ENDPOINT}/study/flashcards/${card.id}/progress`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${user.access_token}`,
+        },
+        body: JSON.stringify({ quality }),
+      });
+    } catch (err) {
+      console.error("Progress update failed:", err);
+    } finally {
+      setIsRating(false);
+    }
+
+    if (currentIndex < totalCards - 1) {
+      setIsFlipped(false);
+      setCurrentIndex(i => i + 1);
+    } else {
+      setSessionPhase("complete");
+    }
+  };
+
+  if (sessionPhase === "complete") {
+    return (
+      <FlashcardSessionComplete
+        theme={theme}
+        cards={cards}
+        ratings={ratings}
+        onReviewAgain={() => {
+          setCurrentIndex(0);
+          setIsFlipped(false);
+          setRatings({});
+          setSessionPhase("active");
+        }}
+        onNewDeck={onNewDeck}
+      />
+    );
+  }
+
+  const cardSceneStyle = {
+    perspective: "1200px",
+    width: "100%",
+    maxWidth: "560px",
+    height: "320px",
+    cursor: "pointer",
+    userSelect: "none",
+  };
+
+  const cardInnerStyle = {
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    transformStyle: "preserve-3d",
+    transition: "transform 480ms cubic-bezier(0.4, 0, 0.2, 1)",
+    transform: isFlipped ? "rotateY(180deg)" : "rotateY(0deg)",
+  };
+
+  const faceBaseStyle = {
+    position: "absolute",
+    inset: 0,
+    backfaceVisibility: "hidden",
+    WebkitBackfaceVisibility: "hidden",
+    borderRadius: "16px",
+    border: `1px solid ${theme.cardBorder}`,
+    backgroundColor: theme.cardBg,
+    boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+    display: "flex",
+    flexDirection: "column",
+    padding: "24px",
+    overflow: "hidden",
+  };
+
+  const backFaceStyle = {
+    ...faceBaseStyle,
+    transform: "rotateY(180deg)",
+    border: `1px solid ${theme.cardBorderHover}`,
+    backgroundColor: theme.cardBgHover,
+  };
+
+  const arrowBtn = (disabled) => ({
+    width: "40px",
+    height: "40px",
+    borderRadius: "50%",
+    border: `1.5px solid ${disabled ? theme.cardBorder : theme.accent}`,
+    backgroundColor: "transparent",
+    color: disabled ? theme.cardBorder : theme.accent,
+    cursor: disabled ? "default" : "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    fontSize: "22px",
+    lineHeight: 1,
+    transition: "all 150ms ease",
+    fontFamily: "inherit",
+  });
+
+  return (
+    <div className="flex flex-col flex-1" style={{ paddingBottom: "80px" }}>
+      {/* Header */}
+      <div style={{ padding: "0 32px 20px", maxWidth: "760px", width: "100%", margin: "0 auto" }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: "10px" }}>
+          <h2 style={{ margin: 0, fontSize: "20px", fontWeight: "700", color: theme.text }}>
+            {title}
+          </h2>
+          <span style={{ fontSize: "13px", color: theme.textMuted, fontWeight: "600" }}>
+            {currentIndex + 1} / {totalCards}
+          </span>
+        </div>
+        <div style={{ height: "6px", borderRadius: "9999px", backgroundColor: theme.cardBorder, overflow: "hidden" }}>
+          <div
+            style={{
+              height: "100%",
+              width: `${((currentIndex + 1) / totalCards) * 100}%`,
+              borderRadius: "9999px",
+              backgroundColor: theme.accent,
+              transition: "width 400ms ease",
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Card + Arrows */}
+      <div
+        className="flex flex-1 items-center justify-center"
+        style={{ padding: "0 24px", gap: "16px" }}
+      >
+        {/* Left arrow */}
+        <button onClick={handlePrev} disabled={currentIndex === 0} style={arrowBtn(currentIndex === 0)}>
+          ‹
+        </button>
+
+        {/* 3D flip card */}
+        <div style={cardSceneStyle} onClick={() => setIsFlipped(f => !f)}>
+          <div style={cardInnerStyle}>
+
+            {/* Front face */}
+            <div style={faceBaseStyle}>
+              <div className="flex items-center justify-between" style={{ marginBottom: "16px" }}>
+                <span
+                  style={{
+                    backgroundColor: typeStyle.bg,
+                    color: typeStyle.text,
+                    border: `1px solid ${typeStyle.border}`,
+                    borderRadius: "9999px",
+                    padding: "3px 10px",
+                    fontSize: "11px",
+                    fontWeight: "600",
+                  }}
+                >
+                  {typeStyle.label}
+                </span>
+                {isRated && (
+                  <span
+                    style={{
+                      width: "8px",
+                      height: "8px",
+                      borderRadius: "50%",
+                      backgroundColor: ratings[card.id] >= 4 ? "#16a34a" : "#dc2626",
+                      display: "inline-block",
+                    }}
+                  />
+                )}
+              </div>
+              <div className="flex flex-1 items-center justify-center">
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "16px",
+                    fontWeight: "600",
+                    color: theme.text,
+                    lineHeight: "1.6",
+                    textAlign: "center",
+                  }}
+                >
+                  {card.front}
+                </p>
+              </div>
+              <p style={{ margin: 0, fontSize: "12px", color: theme.textMuted, textAlign: "center" }}>
+                Click to reveal answer
+              </p>
+            </div>
+
+            {/* Back face */}
+            <div style={backFaceStyle}>
+              <div style={{ marginBottom: "16px" }}>
+                <span
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: "700",
+                    color: theme.accent,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                  }}
+                >
+                  Answer
+                </span>
+              </div>
+              <div className="flex flex-1 items-center justify-center" style={{ overflowY: "auto" }}>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "14px",
+                    fontWeight: "500",
+                    color: theme.text,
+                    lineHeight: "1.7",
+                    textAlign: "center",
+                  }}
+                >
+                  {card.back}
+                </p>
+              </div>
+              <p style={{ margin: 0, fontSize: "12px", color: theme.textMuted, textAlign: "center" }}>
+                How well did you know this?
+              </p>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Right arrow */}
+        <button onClick={handleNext} disabled={currentIndex === totalCards - 1} style={arrowBtn(currentIndex === totalCards - 1)}>
+          ›
         </button>
       </div>
 
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
-        {isLoading && (
-          <div className="flex flex-col items-center justify-center flex-1 gap-4 py-16">
-            <div className="w-10 h-10 border-3 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
-            <p className="text-gray-600 text-sm">Generating study materials…</p>
-          </div>
-        )}
+      {/* Fixed bottom rating bar */}
+      <div
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          backgroundColor: theme.bg,
+          borderTop: `1px solid ${theme.cardBorder}`,
+          padding: "12px 32px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "12px",
+          zIndex: 10,
+        }}
+      >
+        <button
+          onClick={() => handleRate(1)}
+          disabled={isRating}
+          style={{
+            backgroundColor: "#fee2e2",
+            color: "#b91c1c",
+            border: "1.5px solid #fca5a5",
+            borderRadius: "8px",
+            padding: "10px 28px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: isRating ? "not-allowed" : "pointer",
+            opacity: isRating ? 0.6 : 1,
+            transition: "all 150ms ease",
+            fontFamily: "inherit",
+          }}
+        >
+          Needs Work
+        </button>
+        <button
+          onClick={() => handleRate(4)}
+          disabled={isRating}
+          style={{
+            backgroundColor: "#dcfce7",
+            color: "#15803d",
+            border: "1.5px solid #86efac",
+            borderRadius: "8px",
+            padding: "10px 28px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: isRating ? "not-allowed" : "pointer",
+            opacity: isRating ? 0.6 : 1,
+            transition: "all 150ms ease",
+            fontFamily: "inherit",
+          }}
+        >
+          Already Solid
+        </button>
+      </div>
+    </div>
+  );
+}
 
-        {error && !isLoading && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+function FlashcardSessionComplete({ theme, cards, ratings, onReviewAgain, onNewDeck }) {
+  const solidCount     = Object.values(ratings).filter(q => q >= 4).length;
+  const needsWorkCount = Object.values(ratings).filter(q => q < 4).length;
+  const total          = cards.length;
+  const ratedCount     = Object.keys(ratings).length;
+  const accentText     = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  const solidRatio = ratedCount > 0 ? solidCount / ratedCount : 0;
+  let emoji, message;
+  if (solidRatio >= 0.8)      { emoji = "🎉"; message = "Excellent recall!";  }
+  else if (solidRatio >= 0.5) { emoji = "👍"; message = "Good progress!";     }
+  else                        { emoji = "📖"; message = "Keep reviewing!";     }
+
+  return (
+    <div
+      className="flex flex-col flex-1 items-center justify-center"
+      style={{ padding: "40px 32px" }}
+    >
+      <div
+        style={{
+          backgroundColor: theme.cardBg,
+          border: `1px solid ${theme.cardBorder}`,
+          borderRadius: "20px",
+          padding: "48px 56px",
+          maxWidth: "420px",
+          width: "100%",
+          textAlign: "center",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "12px" }}>{emoji}</div>
+        <h2 style={{ margin: "0 0 8px", fontSize: "22px", fontWeight: "800", color: theme.text }}>
+          {message}
+        </h2>
+        <p style={{ margin: "0 0 28px", fontSize: "14px", color: theme.textMuted }}>
+          Session complete — {total} cards reviewed
+        </p>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "12px",
+            marginBottom: "32px",
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: "#dcfce7",
+              border: "1px solid #86efac",
+              borderRadius: "12px",
+              padding: "16px 12px",
+            }}
+          >
+            <div style={{ fontSize: "28px", fontWeight: "800", color: "#15803d" }}>{solidCount}</div>
+            <div style={{ fontSize: "12px", fontWeight: "600", color: "#16a34a" }}>Already Solid</div>
+          </div>
+          <div
+            style={{
+              backgroundColor: "#fee2e2",
+              border: "1px solid #fca5a5",
+              borderRadius: "12px",
+              padding: "16px 12px",
+            }}
+          >
+            <div style={{ fontSize: "28px", fontWeight: "800", color: "#b91c1c" }}>{needsWorkCount}</div>
+            <div style={{ fontSize: "12px", fontWeight: "600", color: "#dc2626" }}>Needs Work</div>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
+          <button
+            onClick={onReviewAgain}
+            style={{
+              backgroundColor: "transparent",
+              color: theme.text,
+              border: `1.5px solid ${theme.cardBorder}`,
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            Review Again
+          </button>
+          <button
+            onClick={onNewDeck}
+            style={{
+              backgroundColor: theme.accent,
+              color: accentText,
+              border: "none",
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            New Deck
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Shared Components ────────────────────────────────────────────────────────
+
+function SlidingPillNav({ theme, items, activeKey, onSelect }) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const activeIndex = items.findIndex(item => item.key === activeKey);
+  const pillIndex = hoveredIndex !== null ? hoveredIndex : activeIndex;
+  const pct = 100 / items.length;
+
+  return (
+    <div style={{ position: "relative" }} onMouseLeave={() => setHoveredIndex(null)}>
+      {/* Sliding pill */}
+      <div
+        style={{
+          position: "absolute",
+          top: "4px",
+          bottom: "4px",
+          left: `calc(${pillIndex} * ${pct}% + 4px)`,
+          width: `calc(${pct}% - 8px)`,
+          backgroundColor: theme.pillBg,
+          borderRadius: "9999px",
+          transition: "left 200ms ease, opacity 150ms ease",
+          opacity: pillIndex >= 0 ? 1 : 0,
+          zIndex: 0,
+        }}
+      />
+      {/* Nav buttons */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${items.length}, 1fr)`,
+          padding: "4px",
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {items.map((item, i) => {
+          const isHighlighted = pillIndex === i;
+          return (
+            <button
+              key={item.key}
+              onMouseEnter={() => setHoveredIndex(i)}
+              onClick={() => onSelect(item.key)}
+              style={{
+                background: "none",
+                border: "none",
+                padding: "9px 20px",
+                fontSize: "13px",
+                fontWeight: "600",
+                cursor: "pointer",
+                color: isHighlighted ? theme.pillText : theme.textMuted,
+                borderRadius: "9999px",
+                transition: "color 150ms ease",
+                textAlign: "center",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function HomePage({ theme, onNavigate }) {
+  const [hoveredCard, setHoveredCard] = useState(null);
+
+  return (
+    <div className="flex flex-col items-center flex-1 px-6" style={{ paddingBottom: "48px" }}>
+      {/* Hero */}
+      <section
+        className="flex flex-col items-center text-center"
+        style={{ paddingTop: "64px", paddingBottom: "48px", maxWidth: "560px" }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "20px" }}>📚</div>
+        <h1
+          style={{
+            color: theme.accent,
+            fontSize: "clamp(2rem, 5vw, 3rem)",
+            fontWeight: "800",
+            margin: "0 0 16px 0",
+            lineHeight: "1.15",
+          }}
+        >
+          Study Materials
+        </h1>
+        <p
+          style={{
+            color: theme.textMuted,
+            fontSize: "1rem",
+            margin: 0,
+            lineHeight: "1.7",
+          }}
+        >
+          practice and understand concepts from piazza course — learn faster!
+        </p>
+      </section>
+
+      {/* Navigation cards */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: "16px",
+          width: "100%",
+          maxWidth: "640px",
+          marginTop: "8px",
+        }}
+      >
+        {SECTION_ITEMS.map((item, i) => (
+          <button
+            key={item.key}
+            onClick={() => onNavigate(item.key)}
+            onMouseEnter={() => setHoveredCard(i)}
+            onMouseLeave={() => setHoveredCard(null)}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              textAlign: "center",
+              padding: "28px 16px",
+              backgroundColor: hoveredCard === i ? theme.cardBgHover : theme.cardBg,
+              border: `1.5px solid ${hoveredCard === i ? theme.cardBorderHover : theme.cardBorder}`,
+              borderRadius: "14px",
+              cursor: "pointer",
+              transition: "all 180ms ease",
+              transform: hoveredCard === i ? "translateY(-3px)" : "translateY(0)",
+              boxShadow:
+                hoveredCard === i
+                  ? "0 10px 30px rgba(0,0,0,0.12)"
+                  : "0 2px 8px rgba(0,0,0,0.05)",
+              color: theme.text,
+            }}
+          >
+            <span style={{ fontSize: "30px", marginBottom: "12px" }}>{item.icon}</span>
+            <span style={{ fontSize: "13px", fontWeight: "700", marginBottom: "6px" }}>
+              {item.label}
+            </span>
+            <span style={{ fontSize: "11px", color: theme.textMuted, lineHeight: "1.5" }}>
+              {item.desc}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SectionView({ theme, view, isLoading, result, error }) {
+  return (
+    <div className="flex flex-col flex-1 px-6" style={{ paddingBottom: "48px" }}>
+      {/* Content area */}
+      <div
+        className="flex-1 flex flex-col items-center justify-center"
+        style={{ maxWidth: "720px", width: "100%", margin: "0 auto" }}
+      >
+        {isLoading && <Spinner theme={theme} />}
+
+        {!isLoading && error && (
+          <div
+            style={{
+              background: "#fee2e2",
+              border: "1px solid #fecaca",
+              borderRadius: "10px",
+              padding: "16px 20px",
+              color: "#b91c1c",
+              fontSize: "14px",
+              width: "100%",
+            }}
+          >
             {error}
           </div>
         )}
 
-        {results && !isLoading && (
-          <>
-            <Section title="Quiz" data={results.quiz} />
-            <Section title="Flashcards" data={results.flashcards} />
-            <Section title="Summary" data={results.summary} />
-          </>
+        {!isLoading && result && (
+          <div
+            style={{
+              backgroundColor: theme.cardBg,
+              borderRadius: "14px",
+              border: `1px solid ${theme.cardBorder}`,
+              overflow: "hidden",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                padding: "14px 20px",
+                borderBottom: `1px solid ${theme.cardBorder}`,
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "700", color: theme.text }}>
+                {SECTION_ITEMS.find(n => n.key === view)?.label}
+              </h3>
+            </div>
+            <pre
+              style={{
+                padding: "16px 20px",
+                fontSize: "12px",
+                color: theme.textMuted,
+                overflowX: "auto",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                margin: 0,
+              }}
+            >
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </div>
         )}
       </div>
     </div>
   );
 }
 
-function Section({ title, data }) {
+function Spinner({ theme }) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
-        <h3 className="text-sm font-semibold text-gray-800 m-0">{title}</h3>
-      </div>
-      <pre className="p-4 text-xs text-gray-700 overflow-x-auto whitespace-pre-wrap break-words m-0">
-        {JSON.stringify(data, null, 2)}
-      </pre>
+    <div className="flex flex-col items-center gap-4">
+      <div
+        className="animate-spin"
+        style={{
+          width: "52px",
+          height: "52px",
+          borderRadius: "50%",
+          border: `5px solid ${theme.spinnerTrack}`,
+          borderTopColor: theme.spinnerFill,
+        }}
+      />
+      <p style={{ color: theme.textMuted, fontSize: "14px", margin: 0 }}>
+        Generating content…
+      </p>
     </div>
   );
 }

--- a/frontend/src/studytab/index.html
+++ b/frontend/src/studytab/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Study Materials – ThreadSense AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/studytab/main.jsx
+++ b/frontend/src/studytab/main.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "../popup/popup.css";
+import StudyMaterialsPage from "../popup/StudyMaterialsPage";
+
+/* global chrome */
+
+const courseId = new URLSearchParams(window.location.search).get("course_id");
+
+function StudyTab() {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    chrome.storage.local.get(["user", "authToken", "tokenExpiry"], (result) => {
+      if (result.user && result.authToken) {
+        if (result.tokenExpiry && Date.now() > result.tokenExpiry) {
+          setUser(null);
+        } else {
+          setUser({ ...result.user, access_token: result.authToken });
+        }
+      }
+      setIsLoading(false);
+    });
+  }, []);
+
+  const handleLogout = () => {
+    chrome.storage.local.remove(
+      ["user", "authToken", "refreshToken", "tokenExpiry"],
+      () => window.close()
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-10 h-10 border-4 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-screen text-gray-600">
+        Not authenticated. Please log in via the extension popup.
+      </div>
+    );
+  }
+
+  return (
+    <StudyMaterialsPage
+      user={user}
+      piazzaCourseId={courseId}
+      onLogout={handleLogout}
+    />
+  );
+}
+
+const root = createRoot(document.getElementById("root"));
+root.render(<StudyTab />);

--- a/frontend/webpack.config.cjs
+++ b/frontend/webpack.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
     content: "./src/content/content.js",
     background: "./src/background/background.js",
     popup: "./src/popup/main.jsx",
+    studytab: "./src/studytab/main.jsx",
   },
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -79,6 +80,11 @@ module.exports = {
       template: "./src/popup/index.html",
       filename: "popup.html",
       chunks: ["popup"],
+    }),
+    new HtmlWebpackPlugin({
+      template: "./src/studytab/index.html",
+      filename: "studytab.html",
+      chunks: ["studytab"],
     }),
     new CopyPlugin({
       patterns: [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["backend"],
+  "venvPath": "backend",
+  "venv": ".venv",
+  "pythonVersion": "3.11",
+  "pythonPlatform": "Windows",
+  "executionEnvironments": [
+    {
+      "root": "backend",
+      "pythonVersion": "3.11",
+      "extraPaths": ["backend"]
+    }
+  ]
+}

--- a/supabase/migrations/20260221000130_create_study_material.sql
+++ b/supabase/migrations/20260221000130_create_study_material.sql
@@ -34,7 +34,7 @@ CREATE TABLE flashcards (
     deck_id UUID REFERENCES flashcard_decks(id) ON DELETE CASCADE,
     front TEXT NOT NULL,
     back TEXT NOT NULL,
-    card_type TEXT DEFAULT 'basic', -- basic, cloze
+    card_type TEXT DEFAULT 'concept', -- concept, definition, qa
     -- Spaced repetition fields (SM-2 algorithm)
     ease_factor DECIMAL(3,2) DEFAULT 2.5,
     interval_days INT DEFAULT 0,


### PR DESCRIPTION
## Summary

- **Database**: Added Supabase migration with 5 new tables (`quizzes`, `quiz_attempts`,
  `flashcard_decks`, `flashcards`, `summaries`). Quizzes store questions as JSONB,
  flashcards include SM-2 spaced repetition fields (`ease_factor`, `interval_days`,
  `next_review`, `review_count`), and summaries support categorization by type
  (thread, weekly, exam_guide).

- **LLM Integration**: Built `study_generator.py` using LangChain + Groq. Quizzes and
  flashcards are generated from ingested Piazza post chunks with structured JSON output
  parsing and fenced-block fallback extraction. Summaries are streamed. Pydantic
  TypeAdapters are used to inject JSON schema into prompts for reliable structured output.

- **Backend Endpoints** (`study_materials.py`): Full REST API covering:
  - `POST /quiz/generate` — generate and persist a quiz from course posts
  - `POST /quiz/submit` — submit answers, calculate and store score
  - `GET  /quiz/{id}/results` — retrieve attempt results
  - `DELETE /quiz/{id}` — delete a quiz
  - `POST /flashcard/generate` — generate a flashcard deck
  - `POST /flashcard/review` — submit a card review and apply SM-2 update
  - `GET  /flashcard/deck/{id}` — retrieve a deck with due cards
  - `DELETE /flashcard/deck/{id}` — delete a deck
  - `POST /summary/generate` — generate and store a summary (streamed LLM)
  - `DELETE /summary/{id}` — delete a summary
  - `GET  /study/all` — dashboard endpoint returning all materials for the user

  All routes are protected by JWT auth via `get_current_user`.

- **Pydantic Models** (`models/study_materials.py`): Comprehensive request/response models
  for all study material types including `QuizQuestion`, `FlashcardCard`, and nested
  response shapes.

- **Frontend** (`StudyMaterialsPage.jsx`, ~1400 lines): Tabbed UI for Quizzes, Flashcards,
  and Summaries. Includes an interactive quiz-taking flow with per-question scoring and
  result breakdown, flashcard flip animations with easy/medium/hard spaced repetition
  rating buttons, and collapsible summary cards. All wired to the backend API with auth
  headers.

- **Chrome Extension**: Added a standalone Study Tab (`studytab/`) as a dedicated extension
  page with its own HTML entry point and React root. Registered in `manifest.json` and
  bundled as a separate webpack entry.

## Test plan

- [ ] Run Supabase migration and verify all 5 tables are created with correct schemas and FK constraints
- [ ] Test quiz generation with easy/medium/hard difficulty and with/without source post filters
- [ ] Submit a quiz attempt and verify score calculation and persistence in `quiz_attempts`
- [ ] Generate a flashcard deck and complete a spaced repetition review session; confirm SM-2 fields update correctly
- [ ] Generate summaries for each type (thread, weekly, exam_guide) and confirm content is stored
- [ ] Open the Study Tab from the Chrome extension; confirm all three tabs render and load existing materials
- [ ] Verify the `/study/all` dashboard endpoint returns quizzes, decks, and summaries for the authenticated user
- [ ] Confirm auth middleware rejects unauthenticated requests with 401