### PR TITLE
Feature/study material generator

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -24,7 +24,7 @@ router = APIRouter()
 @router.post(
     "/signup", response_model=SignUpResponse, status_code=status.HTTP_201_CREATED
 )
-def signup(user_data: SignUpRequest):
+def signup(user_data: SignUpRequest) -> SignUpResponse:
     """
     Register a new user via Supabase Auth and persist their profile to the local database.
 
@@ -116,7 +116,7 @@ def signup(user_data: SignUpRequest):
 
 
 @router.post("/login", response_model=LoginResponse, status_code=status.HTTP_200_OK)
-def login(credentials: LoginRequest):
+def login(credentials: LoginRequest) -> LoginResponse:
     """
     Authenticate a user and return access tokens.
 
@@ -200,11 +200,15 @@ def login(credentials: LoginRequest):
             detail="Failed to retrieve user profile",
         )
 
+    # Safely extract user data with fallbacks
+    display_name = user_profile.get("display_name", "") if user_profile else ""
+    user_email = user.email or ""
+
     return LoginResponse(
         user={
             "id": user.id,
-            "name": user_profile["display_name"],
-            "email": user.email,
+            "name": display_name,
+            "email": user_email,
         },
         access_token=session.access_token,
         refresh_token=session.refresh_token,

--- a/backend/app/api/endpoints/chat_sessions.py
+++ b/backend/app/api/endpoints/chat_sessions.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, List, Optional
 from uuid import UUID
 
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
 from app.core.database import execute_insert, execute_query, execute_statement

--- a/backend/app/api/endpoints/chat_sessions.py
+++ b/backend/app/api/endpoints/chat_sessions.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, List, Optional
 from uuid import UUID
 
-
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
 from app.core.database import execute_insert, execute_query, execute_statement

--- a/backend/app/api/endpoints/chat_sessions.py
+++ b/backend/app/api/endpoints/chat_sessions.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+import logging
+from typing import Any, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
@@ -12,10 +13,12 @@ from app.models.chat_session import (
     ChatSessionUpdate,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-async def get_current_user(authorization: Optional[str] = Header(None)):
+async def get_current_user(authorization: Optional[str] = Header(None)) -> Any:
+    """Validate authorization token and return current user."""
     if not authorization:
         raise HTTPException(status_code=401, detail="Missing authorization header")
 
@@ -26,9 +29,7 @@ async def get_current_user(authorization: Optional[str] = Header(None)):
             raise HTTPException(status_code=401, detail="Invalid token")
         return user.user
     except Exception as e:
-        import logging
-
-        logging.error(f"Authentication failed: {str(e)}")
+        logger.error(f"Authentication failed: {str(e)}")
         raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
 
 
@@ -229,7 +230,7 @@ async def get_daily_query_count(user=Depends(get_current_user)):
               AND cm.created_at >= CURRENT_DATE
         """
         result = execute_query(query, (user.id,), fetch_one=True)
-        count = result["count"] if result else 0
+        count = result.get("count", 0) if result else 0
         return {"count": count}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch stats: {str(e)}")

--- a/backend/app/api/endpoints/ingestion.py
+++ b/backend/app/api/endpoints/ingestion.py
@@ -171,7 +171,9 @@ async def get_ingestion_status(request: IngestRequest):
                 WHERE c.name = %s
             """
             result = execute_query(count_query, (request.thread_id,))
-            ingested_count = result[0].get("count", 0) if result and len(result) > 0 else 0
+            ingested_count = (
+                result[0].get("count", 0) if result and len(result) > 0 else 0
+            )
         except Exception as e:
             logger.warning(f"Failed to get ingested count: {e}")
             ingested_count = 0

--- a/backend/app/api/endpoints/ingestion.py
+++ b/backend/app/api/endpoints/ingestion.py
@@ -51,7 +51,7 @@ def run_ingestion_task(thread_id: str, piazza_cookie: str):
         orchestrator = ThreadIngestionOrchestrator(piazza_cookie)
         orchestrator.ingest_by_thread_id(thread_id=thread_id)
         logger.info(f"Successfully ingested thread {thread_id}")
-    except Exception as e:
+    except Exception:
         logger.exception(f"Background ingestion failed for thread {thread_id}")
 
 

--- a/backend/app/api/endpoints/ingestion.py
+++ b/backend/app/api/endpoints/ingestion.py
@@ -2,12 +2,15 @@
 Data ingestion API endpoint for Piazza threads.
 """
 
+import logging
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel, Field
 
 from app.threadIngestion import ThreadIngestionOrchestrator
+
+logger = logging.getLogger(__name__)
 
 
 class IngestRequest(BaseModel):
@@ -47,9 +50,9 @@ def run_ingestion_task(thread_id: str, piazza_cookie: str):
     try:
         orchestrator = ThreadIngestionOrchestrator(piazza_cookie)
         orchestrator.ingest_by_thread_id(thread_id=thread_id)
-        # We could log success here or update a status in DB if we had a jobs table
+        logger.info(f"Successfully ingested thread {thread_id}")
     except Exception as e:
-        print(f"Background ingestion failed for thread {thread_id}: {e}")
+        logger.exception(f"Background ingestion failed for thread {thread_id}")
 
 
 @router.post("/ingest", response_model=IngestResponse)
@@ -168,8 +171,9 @@ async def get_ingestion_status(request: IngestRequest):
                 WHERE c.name = %s
             """
             result = execute_query(count_query, (request.thread_id,))
-            ingested_count = result[0]["count"] if result else 0
-        except Exception:
+            ingested_count = result[0].get("count", 0) if result and len(result) > 0 else 0
+        except Exception as e:
+            logger.warning(f"Failed to get ingested count: {e}")
             ingested_count = 0
 
         # 2. Get total posts count from Piazza API
@@ -216,11 +220,9 @@ async def get_ingestion_status(request: IngestRequest):
             WHERE piazza_course_id = %s
         """
         db_result = execute_query(db_query, (request.thread_id,))
-        last_id = (
-            db_result[0]["last_ingested_post_id"]
-            if db_result and db_result[0]["last_ingested_post_id"] is not None
-            else 0
-        )
+        last_id = 0
+        if db_result and len(db_result) > 0:
+            last_id = db_result[0].get("last_ingested_post_id") or 0
 
         return IngestionStatusResponse(
             ingested_posts_count=ingested_count,

--- a/backend/app/api/endpoints/llm.py
+++ b/backend/app/api/endpoints/llm.py
@@ -2,12 +2,16 @@
 LLM API endpoint for text generation.
 """
 
+import logging
+import os
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
 from app.models import QueryRequest
 from app.textGeneration import stream_llm_response
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -24,7 +28,7 @@ async def generate_llm_response(request: QueryRequest):
             media_type="application/x-ndjson",
         )
     except Exception as e:
-        print(e)
+        logger.exception("Failed to generate LLM response")
         raise HTTPException(
             status_code=500,
             detail=f"Failed to generate response: {str(e)}",
@@ -34,8 +38,6 @@ async def generate_llm_response(request: QueryRequest):
 @router.get("/health")
 async def llm_health_check():
     """Check if the LLM service is configured."""
-    import os
-
     api_key = os.getenv("GROQ_API_KEY")
     return {
         "status": "healthy" if api_key else "unhealthy",

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -6,12 +6,15 @@ Generates quizzes, flashcards, etc
 from fastapi import APIRouter, HTTPException, status
 import logging
 from uuid import UUID
+from psycopg2.extras import Json
 
+from app.core.database import execute_query, execute_statement
 from app.models.study_materials import (
     QuizGenerateRequest, QuizResponse, QuizSubmitRequest, QuizResultResponse, QuizDeleteResponse,
     FlashcardRequestGenerate, FlashcardAllResponse, FlashcardReviewRequest, FlashcardResponse, FlashcardDeleteResponse,
     SummaryGenerateRequest, SummaryResponse, AllStudyMaterialsResponse,
 )
+from app.textGeneration import generate_quiz_questions
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +25,94 @@ router = APIRouter()
 
 @router.post("/quiz/generate", response_model=QuizResponse)
 async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
-    pass
+    try:
+        generated = generate_quiz_questions(
+            piazza_course_id=quiz_info.piazza_course_id,
+            title=quiz_info.title,
+            difficulty=quiz_info.difficulty,
+            num_questions=quiz_info.num_questions,
+            source_posts=quiz_info.source_posts,
+        )
+
+        insert_query = """
+        INSERT INTO quizzes (
+            piazza_course_id, title, difficulty, questions, source_posts
+        )
+        VALUES (%s, %s, %s, %s, %s)
+        RETURNING id, title, difficulty, questions,
+                  COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                  created_at
+        """
+        quiz_row = execute_query(
+            insert_query,
+            (
+                quiz_info.piazza_course_id,
+                quiz_info.title,
+                quiz_info.difficulty,
+                Json(generated["questions"]),
+                generated["source_posts"],
+            ),
+            fetch_one=True,
+        )
+
+        if not quiz_row:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to persist generated quiz",
+            )
+
+        return QuizResponse.model_validate(quiz_row)
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        logger.exception("Failed to generate quiz")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate quiz: {str(e)}",
+        )
 
 @router.get("/quiz/{id}", response_model=QuizResponse)
 async def get_quiz(id: UUID) -> QuizResponse:
-    pass
+    try:
+        query = """
+        SELECT id, title, difficulty, questions,
+               COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+               created_at
+        FROM quizzes
+        WHERE id = %s
+        """
+
+        quiz = execute_query(query, (str(id),), fetch_one=True)
+
+        if not quiz:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
+            )
+        
+        return QuizResponse.model_validate(quiz)
+    
+    except HTTPException:
+        raise
+
+    except Exception as e:
+        logger.exception("Failed to fetch quiz")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch quiz: {str(e)}",
+        )
+
+
+        
+
+
+
+    
 
 @router.post("/quiz/{id}/submit", response_model=QuizResultResponse)
 async def submit_quiz_answer(id: UUID, submission: QuizSubmitRequest) -> QuizResultResponse:
@@ -34,11 +120,59 @@ async def submit_quiz_answer(id: UUID, submission: QuizSubmitRequest) -> QuizRes
 
 @router.get("/quiz", response_model=list[QuizResponse])
 async def get_all_quizzes() -> list[QuizResponse]:
-    pass
+    """
+    Get all quizzes
+    """
+    try:
+        query = """
+        SELECT id, title, difficulty, questions,
+               COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+               created_at
+        FROM quizzes
+        ORDER BY created_at DESC;
+        """
+        quizzes = execute_query(query)
+
+        return [QuizResponse.model_validate(q) for q in (quizzes or [])]
+
+    except HTTPException:
+        raise
+    
+    except Exception as e:
+        logger.exception("Failed to fetch quizzes")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch quizzes: {str(e)}",
+        )
+    
+    
 
 @router.delete("/quiz/{id}", response_model=QuizDeleteResponse)
 async def delete_quiz(id: UUID) -> QuizDeleteResponse:
-    pass
+    """
+    Delete given quiz from quiz id 
+    """
+    try:
+        query = """
+        DELETE FROM quizzes 
+        WHERE id = %s
+        """
+        affected = execute_statement(query, (str(id),))
+
+        if affected == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
+            )
+
+        return QuizDeleteResponse(id=id, deleted=True, message="Quiz deleted successfully")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to delete quiz")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete quiz: {str(e)}",
+        )
 
 # -------- FLASHCARDS -------- #
 

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -5,7 +5,13 @@ Generates quizzes, flashcards, etc
 
 from fastapi import APIRouter, HTTPException, status
 import logging
+from uuid import UUID
 
+from app.models.study_materials import (
+    QuizGenerateRequest, QuizResponse, QuizSubmitRequest, QuizResultResponse, QuizDeleteResponse,
+    FlashcardRequestGenerate, FlashcardAllResponse, FlashcardReviewRequest, FlashcardResponse, FlashcardDeleteResponse,
+    SummaryGenerateRequest, SummaryResponse, AllStudyMaterialsResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -14,52 +20,54 @@ router = APIRouter()
 
 # -------- QUIZ -------- #
 
-@router.post("/quiz/generate")
-async def quiz_generate():
+@router.post("/quiz/generate", response_model=QuizResponse)
+async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
     pass
 
-@router.get("/quiz/{id}")
-async def get_quiz():
+@router.get("/quiz/{id}", response_model=QuizResponse)
+async def get_quiz(id: UUID) -> QuizResponse:
     pass
 
-@router.post("/quiz/{id}/submit")
-async def submit_quiz_answer():
+@router.post("/quiz/{id}/submit", response_model=QuizResultResponse)
+async def submit_quiz_answer(id: UUID, submission: QuizSubmitRequest) -> QuizResultResponse:
     pass
 
-@router.get("/quiz")
-async def get_all_quizzes():
+@router.get("/quiz", response_model=list[QuizResponse])
+async def get_all_quizzes() -> list[QuizResponse]:
     pass
 
-@router.delete("/quiz/{id}")
-async def delete_quiz():
+@router.delete("/quiz/{id}", response_model=QuizDeleteResponse)
+async def delete_quiz(id: UUID) -> QuizDeleteResponse:
     pass
 
 # -------- FLASHCARDS -------- #
 
-@router.post("/flashcards/generate")
-async def flashcards_generate():
-    pass
-    
-@router.get("/flashcards/{deck_id}")
-async def get_flashcards():
+@router.post("/flashcards/generate", response_model=FlashcardAllResponse)
+async def flashcards_generate(deck_info: FlashcardRequestGenerate) -> FlashcardAllResponse:
     pass
 
-@router.put("/flashcards/{deck_id}/progress")
-async def update_flashcard_mastery():
+@router.get("/flashcards/{deck_id}", response_model=FlashcardAllResponse)
+async def get_flashcards(deck_id: UUID) -> FlashcardAllResponse:
     pass
 
-@router.get("/flashcards")
-async def get_all_flashcards():
+@router.put("/flashcards/{deck_id}/progress", response_model=FlashcardResponse)
+async def update_flashcard_mastery(deck_id: UUID, review: FlashcardReviewRequest) -> FlashcardResponse:
     pass
 
-@router.delete("/flashcards/{deck_id}", res)
-async def delete_flashcard_deck():
+@router.get("/flashcards", response_model=list[FlashcardAllResponse])
+async def get_all_flashcards() -> list[FlashcardAllResponse]:
     pass
 
-@router.post("/summary/generate")
-async def generate_summary():
+@router.delete("/flashcards/{deck_id}", response_model=FlashcardDeleteResponse)
+async def delete_flashcard_deck(deck_id: UUID) -> FlashcardDeleteResponse:
     pass
 
-@router.get("/materials")
-async def list_all_study_materials():
+# -------- SUMMARY -------- #
+
+@router.post("/summary/generate", response_model=SummaryResponse)
+async def generate_summary(summary_info: SummaryGenerateRequest) -> SummaryResponse:
+    pass
+
+@router.get("/materials", response_model=AllStudyMaterialsResponse)
+async def list_all_study_materials() -> AllStudyMaterialsResponse:
     pass

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -3,33 +3,34 @@ Study Material API Endpoints
 Generates quizzes, flashcards, etc
 """
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
 import logging
 from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from psycopg2.extras import Json
 
 from app.core.database import execute_query, execute_statement
 from app.core.supabase import supabase
 from app.models.study_materials import (
+    AllStudyMaterialsResponse,
+    FlashcardAllResponse,
+    FlashcardDeleteResponse,
+    FlashcardRequestGenerate,
+    FlashcardResponse,
+    FlashcardReviewRequest,
+    QuizDeleteResponse,
     QuizGenerateRequest,
     QuizResponse,
-    QuizSubmitRequest,
     QuizResultResponse,
-    QuizDeleteResponse,
-    FlashcardRequestGenerate,
-    FlashcardAllResponse,
-    FlashcardReviewRequest,
-    FlashcardResponse,
-    FlashcardDeleteResponse,
+    QuizSubmitRequest,
     SummaryGenerateRequest,
     SummaryResponse,
-    AllStudyMaterialsResponse,
 )
 from app.textGeneration import (
-    generate_quiz_questions,
     generate_flashcard_stream,
+    generate_quiz_questions,
     generate_summary,
 )
 
@@ -246,7 +247,7 @@ async def delete_quiz(id: UUID) -> QuizDeleteResponse:
     """
     try:
         query = """
-        DELETE FROM quizzes 
+        DELETE FROM quizzes
         WHERE id = %s
         """
         affected = execute_statement(query, (str(id),))

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -3,28 +3,61 @@ Study Material API Endpoints
 Generates quizzes, flashcards, etc
 """
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
 from uuid import UUID
 from psycopg2.extras import Json
 
 from app.core.database import execute_query, execute_statement
+from app.core.supabase import supabase
 from app.models.study_materials import (
-    QuizGenerateRequest, QuizResponse, QuizSubmitRequest, QuizResultResponse, QuizDeleteResponse,
-    FlashcardRequestGenerate, FlashcardAllResponse, FlashcardReviewRequest, FlashcardResponse, FlashcardDeleteResponse,
-    SummaryGenerateRequest, SummaryResponse, AllStudyMaterialsResponse,
+    QuizGenerateRequest,
+    QuizResponse,
+    QuizSubmitRequest,
+    QuizResultResponse,
+    QuizDeleteResponse,
+    FlashcardRequestGenerate,
+    FlashcardAllResponse,
+    FlashcardReviewRequest,
+    FlashcardResponse,
+    FlashcardDeleteResponse,
+    SummaryGenerateRequest,
+    SummaryResponse,
+    AllStudyMaterialsResponse,
 )
-from app.textGeneration import generate_quiz_questions
+from app.textGeneration import generate_quiz_questions, generate_flashcard_stream, generate_summary
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+async def get_current_user(authorization: Optional[str] = Header(None)) -> Any:
+    """Validate authorization token and return current user."""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization header")
+    try:
+        token = authorization.replace("Bearer ", "")
+        user = supabase.auth.get_user(token)
+        if not user or not user.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user.user
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+
+
 # -------- QUIZ -------- #
 
+
 @router.post("/quiz/generate", response_model=QuizResponse)
-async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
+async def quiz_generate(
+    quiz_info: QuizGenerateRequest, user=Depends(get_current_user)
+) -> QuizResponse:
     try:
         generated = generate_quiz_questions(
             piazza_course_id=quiz_info.piazza_course_id,
@@ -36,9 +69,9 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
 
         insert_query = """
         INSERT INTO quizzes (
-            piazza_course_id, title, difficulty, questions, source_posts
+            user_id, piazza_course_id, title, difficulty, questions, source_posts
         )
-        VALUES (%s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s)
         RETURNING id, title, difficulty, questions,
                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
                   created_at
@@ -46,6 +79,7 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
         quiz_row = execute_query(
             insert_query,
             (
+                str(user.id),
                 quiz_info.piazza_course_id,
                 quiz_info.title,
                 quiz_info.difficulty,
@@ -77,6 +111,7 @@ async def quiz_generate(quiz_info: QuizGenerateRequest) -> QuizResponse:
             detail=f"Failed to generate quiz: {str(e)}",
         )
 
+
 @router.get("/quiz/{id}", response_model=QuizResponse)
 async def get_quiz(id: UUID) -> QuizResponse:
     try:
@@ -94,9 +129,9 @@ async def get_quiz(id: UUID) -> QuizResponse:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
             )
-        
+
         return QuizResponse.model_validate(quiz)
-    
+
     except HTTPException:
         raise
 
@@ -108,15 +143,69 @@ async def get_quiz(id: UUID) -> QuizResponse:
         )
 
 
-        
-
-
-
-    
-
 @router.post("/quiz/{id}/submit", response_model=QuizResultResponse)
-async def submit_quiz_answer(id: UUID, submission: QuizSubmitRequest) -> QuizResultResponse:
-    pass
+async def submit_quiz_answer(
+    id: UUID, submission: QuizSubmitRequest
+) -> QuizResultResponse:
+    try:
+        quiz = execute_query(
+            "SELECT id, questions FROM quizzes WHERE id = %s",
+            (str(id),),
+            fetch_one=True,
+        )
+        if not quiz:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
+            )
+
+        questions = quiz["questions"]
+        user_answers = submission.answers
+
+        if len(user_answers) != len(questions):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Expected {len(questions)} answers, got {len(user_answers)}",
+            )
+
+        correct_count = 0
+        for q, user_ans in zip(questions, user_answers):
+            correct = q["correct_answer"]
+            if isinstance(correct, list):
+                if isinstance(user_ans, list) and sorted(user_ans) == sorted(correct):
+                    correct_count += 1
+            else:
+                if user_ans == correct:
+                    correct_count += 1
+
+        total = len(questions)
+        score = round((correct_count / total) * 100, 2) if total else 0.0
+        now = datetime.now(timezone.utc)
+
+        execute_statement(
+            """
+            INSERT INTO quiz_attempts (quiz_id, answers, score, completed_at)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (str(id), Json(user_answers), score, now),
+        )
+
+        return QuizResultResponse(
+            quiz_id=id,
+            score=score,
+            correct_count=correct_count,
+            total_count=total,
+            completed_at=now,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to submit quiz")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to submit quiz: {str(e)}",
+        )
+
 
 @router.get("/quiz", response_model=list[QuizResponse])
 async def get_all_quizzes() -> list[QuizResponse]:
@@ -137,20 +226,19 @@ async def get_all_quizzes() -> list[QuizResponse]:
 
     except HTTPException:
         raise
-    
+
     except Exception as e:
         logger.exception("Failed to fetch quizzes")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to fetch quizzes: {str(e)}",
         )
-    
-    
+
 
 @router.delete("/quiz/{id}", response_model=QuizDeleteResponse)
 async def delete_quiz(id: UUID) -> QuizDeleteResponse:
     """
-    Delete given quiz from quiz id 
+    Delete given quiz from quiz id
     """
     try:
         query = """
@@ -164,7 +252,9 @@ async def delete_quiz(id: UUID) -> QuizDeleteResponse:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found"
             )
 
-        return QuizDeleteResponse(id=id, deleted=True, message="Quiz deleted successfully")
+        return QuizDeleteResponse(
+            id=id, deleted=True, message="Quiz deleted successfully"
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -174,34 +264,361 @@ async def delete_quiz(id: UUID) -> QuizDeleteResponse:
             detail=f"Failed to delete quiz: {str(e)}",
         )
 
+
 # -------- FLASHCARDS -------- #
 
+
 @router.post("/flashcards/generate", response_model=FlashcardAllResponse)
-async def flashcards_generate(deck_info: FlashcardRequestGenerate) -> FlashcardAllResponse:
-    pass
+async def flashcards_generate(
+    deck_info: FlashcardRequestGenerate, user=Depends(get_current_user)
+) -> FlashcardAllResponse:
+    try:
+        generated = generate_flashcard_stream(
+            piazza_course_id=deck_info.piazza_course_id,
+            title=deck_info.title,
+            tags=deck_info.tags,
+            source_posts=deck_info.source_posts,
+        )
+
+        deck_row = execute_query(
+            """
+            INSERT INTO flashcard_decks (user_id, piazza_course_id, title, tags)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, title, tags, created_at
+            """,
+            (str(user.id), deck_info.piazza_course_id, deck_info.title, deck_info.tags),
+            fetch_one=True,
+        )
+
+        if not deck_row:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to persist flashcard deck",
+            )
+
+        deck_id = deck_row["id"]
+
+        if generated["cards"]:
+            card_values = [
+                (deck_id, c["front"], c["back"], c["card_type"])
+                for c in generated["cards"]
+            ]
+            placeholders = ", ".join("(%s, %s, %s, %s)" for _ in card_values)
+            flat_params = [v for row in card_values for v in row]
+            cards_rows = execute_query(
+                f"""
+                INSERT INTO flashcards (deck_id, front, back, card_type)
+                VALUES {placeholders}
+                RETURNING id, front, back, card_type,
+                          ease_factor, interval_days, next_review, review_count
+                """,
+                tuple(flat_params),
+            )
+        else:
+            cards_rows = []
+
+        return FlashcardAllResponse(
+            id=deck_row["id"],
+            title=deck_row["title"],
+            tags=deck_row["tags"],
+            created_at=deck_row["created_at"],
+            cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to generate flashcards")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate flashcards: {str(e)}",
+        )
+
 
 @router.get("/flashcards/{deck_id}", response_model=FlashcardAllResponse)
 async def get_flashcards(deck_id: UUID) -> FlashcardAllResponse:
-    pass
+    try:
+        deck_row = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks WHERE id = %s",
+            (str(deck_id),),
+            fetch_one=True,
+        )
 
-@router.put("/flashcards/{deck_id}/progress", response_model=FlashcardResponse)
-async def update_flashcard_mastery(deck_id: UUID, review: FlashcardReviewRequest) -> FlashcardResponse:
-    pass
+        if not deck_row:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard deck not found"
+            )
+
+        cards_rows = execute_query(
+            """
+            SELECT id, front, back, card_type,
+                   ease_factor, interval_days, next_review, review_count
+            FROM flashcards WHERE deck_id = %s ORDER BY id
+            """,
+            (str(deck_id),),
+        )
+
+        return FlashcardAllResponse(
+            id=deck_row["id"],
+            title=deck_row["title"],
+            tags=deck_row["tags"],
+            created_at=deck_row["created_at"],
+            cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to fetch flashcard deck")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch flashcard deck: {str(e)}",
+        )
+
+
+@router.put("/flashcards/{card_id}/progress", response_model=FlashcardResponse)
+async def update_flashcard_mastery(
+    card_id: UUID, review: FlashcardReviewRequest
+) -> FlashcardResponse:
+    """Apply one SM-2 review step to a single flashcard. quality 0-5."""
+    try:
+        card = execute_query(
+            """
+            SELECT id, ease_factor, interval_days, review_count
+            FROM flashcards WHERE id = %s
+            """,
+            (str(card_id),),
+            fetch_one=True,
+        )
+
+        if not card:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard not found"
+            )
+
+        q = review.quality
+        ef = float(card["ease_factor"])
+        interval = int(card["interval_days"])
+        review_count = int(card["review_count"])
+
+        # SM-2 algorithm
+        if q < 3:
+            interval = 0
+            review_count = 0
+        else:
+            if review_count == 0:
+                interval = 1
+            elif review_count == 1:
+                interval = 6
+            else:
+                interval = round(interval * ef)
+            review_count += 1
+
+        ef = max(1.3, ef + 0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+
+        updated = execute_query(
+            """
+            UPDATE flashcards
+            SET ease_factor   = %s,
+                interval_days = %s,
+                next_review   = NOW() + (%s || ' days')::interval,
+                review_count  = %s
+            WHERE id = %s
+            RETURNING id, front, back, card_type,
+                      ease_factor, interval_days, next_review, review_count
+            """,
+            (round(ef, 2), interval, interval, review_count, str(card_id)),
+            fetch_one=True,
+        )
+
+        return FlashcardResponse.model_validate(updated)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to update flashcard progress")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update flashcard progress: {str(e)}",
+        )
+
 
 @router.get("/flashcards", response_model=list[FlashcardAllResponse])
 async def get_all_flashcards() -> list[FlashcardAllResponse]:
-    pass
+    try:
+        decks = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks ORDER BY created_at DESC"
+        )
+
+        result = []
+        for deck in (decks or []):
+            cards_rows = execute_query(
+                """
+                SELECT id, front, back, card_type,
+                       ease_factor, interval_days, next_review, review_count
+                FROM flashcards WHERE deck_id = %s ORDER BY id
+                """,
+                (str(deck["id"]),),
+            )
+            result.append(FlashcardAllResponse(
+                id=deck["id"],
+                title=deck["title"],
+                tags=deck["tags"],
+                created_at=deck["created_at"],
+                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+            ))
+
+        return result
+
+    except Exception as e:
+        logger.exception("Failed to fetch flashcard decks")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch flashcard decks: {str(e)}",
+        )
+
 
 @router.delete("/flashcards/{deck_id}", response_model=FlashcardDeleteResponse)
 async def delete_flashcard_deck(deck_id: UUID) -> FlashcardDeleteResponse:
-    pass
+    try:
+        affected = execute_statement(
+            "DELETE FROM flashcard_decks WHERE id = %s", (str(deck_id),)
+        )
+
+        if affected == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Flashcard deck not found"
+            )
+
+        return FlashcardDeleteResponse(id=deck_id)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to delete flashcard deck")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete flashcard deck: {str(e)}",
+        )
+
 
 # -------- SUMMARY -------- #
 
+
 @router.post("/summary/generate", response_model=SummaryResponse)
-async def generate_summary(summary_info: SummaryGenerateRequest) -> SummaryResponse:
-    pass
+async def summary_generate(
+    summary_info: SummaryGenerateRequest, user=Depends(get_current_user)
+) -> SummaryResponse:
+    try:
+        generated = generate_summary(
+            piazza_course_id=summary_info.piazza_course_id,
+            title=summary_info.title,
+            summary_type=summary_info.summary_type,
+            source_posts=summary_info.source_posts,
+        )
+
+        row = execute_query(
+            """
+            INSERT INTO summaries (user_id, piazza_course_id, title, content, summary_type, source_posts)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id, title, content, summary_type,
+                      COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                      created_at
+            """,
+            (
+                str(user.id),
+                summary_info.piazza_course_id,
+                summary_info.title,
+                generated["content"],
+                summary_info.summary_type,
+                generated["source_posts"],
+            ),
+            fetch_one=True,
+        )
+
+        if not row:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to persist generated summary",
+            )
+
+        return SummaryResponse.model_validate(row)
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to generate summary")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate summary: {str(e)}",
+        )
+
 
 @router.get("/materials", response_model=AllStudyMaterialsResponse)
-async def list_all_study_materials() -> AllStudyMaterialsResponse:
-    pass
+async def list_all_study_materials(piazza_course_id: str) -> AllStudyMaterialsResponse:
+    try:
+        quiz_rows = execute_query(
+            """
+            SELECT id, title, difficulty, questions,
+                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                   created_at
+            FROM quizzes
+            WHERE piazza_course_id = %s
+            ORDER BY created_at DESC
+            """,
+            (piazza_course_id,),
+        )
+
+        deck_rows = execute_query(
+            "SELECT id, title, tags, created_at FROM flashcard_decks WHERE piazza_course_id = %s ORDER BY created_at DESC",
+            (piazza_course_id,),
+        )
+
+        flashcard_decks = []
+        for deck in (deck_rows or []):
+            cards_rows = execute_query(
+                """
+                SELECT id, front, back, card_type,
+                       ease_factor, interval_days, next_review, review_count
+                FROM flashcards WHERE deck_id = %s ORDER BY id
+                """,
+                (str(deck["id"]),),
+            )
+            flashcard_decks.append(FlashcardAllResponse(
+                id=deck["id"],
+                title=deck["title"],
+                tags=deck["tags"],
+                created_at=deck["created_at"],
+                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
+            ))
+
+        summary_rows = execute_query(
+            """
+            SELECT id, title, content, summary_type,
+                   COALESCE(source_posts, ARRAY[]::text[]) AS source_posts,
+                   created_at
+            FROM summaries
+            WHERE piazza_course_id = %s
+            ORDER BY created_at DESC
+            """,
+            (piazza_course_id,),
+        )
+
+        return AllStudyMaterialsResponse(
+            quizzes=[QuizResponse.model_validate(q) for q in (quiz_rows or [])],
+            flashcard_decks=flashcard_decks,
+            summaries=[SummaryResponse.model_validate(s) for s in (summary_rows or [])],
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to fetch all study materials")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch study materials: {str(e)}",
+        )

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -1,0 +1,65 @@
+"""
+Study Material API Endpoints
+Generates quizzes, flashcards, etc
+"""
+
+from fastapi import APIRouter, HTTPException, status
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# -------- QUIZ -------- #
+
+@router.post("/quiz/generate")
+async def quiz_generate():
+    pass
+
+@router.get("/quiz/{id}")
+async def get_quiz():
+    pass
+
+@router.post("/quiz/{id}/submit")
+async def submit_quiz_answer():
+    pass
+
+@router.get("/quiz")
+async def get_all_quizzes():
+    pass
+
+@router.delete("/quiz/{id}")
+async def delete_quiz():
+    pass
+
+# -------- FLASHCARDS -------- #
+
+@router.post("/flashcards/generate")
+async def flashcards_generate():
+    pass
+    
+@router.get("/flashcards/{deck_id}")
+async def get_flashcards():
+    pass
+
+@router.put("/flashcards/{deck_id}/progress")
+async def update_flashcard_mastery():
+    pass
+
+@router.get("/flashcards")
+async def get_all_flashcards():
+    pass
+
+@router.delete("/flashcards/{deck_id}", res)
+async def delete_flashcard_deck():
+    pass
+
+@router.post("/summary/generate")
+async def generate_summary():
+    pass
+
+@router.get("/materials")
+async def list_all_study_materials():
+    pass

--- a/backend/app/api/endpoints/study_materials.py
+++ b/backend/app/api/endpoints/study_materials.py
@@ -27,7 +27,11 @@ from app.models.study_materials import (
     SummaryResponse,
     AllStudyMaterialsResponse,
 )
-from app.textGeneration import generate_quiz_questions, generate_flashcard_stream, generate_summary
+from app.textGeneration import (
+    generate_quiz_questions,
+    generate_flashcard_stream,
+    generate_summary,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -453,7 +457,7 @@ async def get_all_flashcards() -> list[FlashcardAllResponse]:
         )
 
         result = []
-        for deck in (decks or []):
+        for deck in decks or []:
             cards_rows = execute_query(
                 """
                 SELECT id, front, back, card_type,
@@ -462,13 +466,17 @@ async def get_all_flashcards() -> list[FlashcardAllResponse]:
                 """,
                 (str(deck["id"]),),
             )
-            result.append(FlashcardAllResponse(
-                id=deck["id"],
-                title=deck["title"],
-                tags=deck["tags"],
-                created_at=deck["created_at"],
-                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
-            ))
+            result.append(
+                FlashcardAllResponse(
+                    id=deck["id"],
+                    title=deck["title"],
+                    tags=deck["tags"],
+                    created_at=deck["created_at"],
+                    cards=[
+                        FlashcardResponse.model_validate(r) for r in (cards_rows or [])
+                    ],
+                )
+            )
 
         return result
 
@@ -579,7 +587,7 @@ async def list_all_study_materials(piazza_course_id: str) -> AllStudyMaterialsRe
         )
 
         flashcard_decks = []
-        for deck in (deck_rows or []):
+        for deck in deck_rows or []:
             cards_rows = execute_query(
                 """
                 SELECT id, front, back, card_type,
@@ -588,13 +596,17 @@ async def list_all_study_materials(piazza_course_id: str) -> AllStudyMaterialsRe
                 """,
                 (str(deck["id"]),),
             )
-            flashcard_decks.append(FlashcardAllResponse(
-                id=deck["id"],
-                title=deck["title"],
-                tags=deck["tags"],
-                created_at=deck["created_at"],
-                cards=[FlashcardResponse.model_validate(r) for r in (cards_rows or [])],
-            ))
+            flashcard_decks.append(
+                FlashcardAllResponse(
+                    id=deck["id"],
+                    title=deck["title"],
+                    tags=deck["tags"],
+                    created_at=deck["created_at"],
+                    cards=[
+                        FlashcardResponse.model_validate(r) for r in (cards_rows or [])
+                    ],
+                )
+            )
 
         summary_rows = execute_query(
             """

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 # Import endpoint routers
-from app.api.endpoints import auth, chat_sessions, documents, example, ingestion, llm
+from app.api.endpoints import auth, chat_sessions, documents, example, ingestion, llm, study_materials
 
 # Create main API router
 api_router = APIRouter()
@@ -18,7 +18,7 @@ class MessageResponse(BaseModel):
     message: str
     status: str
 
-
+api_router.include_router(study_materials.router, prefix="/study", tags=["study"])
 # Include example endpoints
 api_router.include_router(example.router, prefix="/example", tags=["users"])
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,7 +6,15 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 # Import endpoint routers
-from app.api.endpoints import auth, chat_sessions, documents, example, ingestion, llm, study_materials
+from app.api.endpoints import (
+    auth,
+    chat_sessions,
+    documents,
+    example,
+    ingestion,
+    llm,
+    study_materials,
+)
 
 # Create main API router
 api_router = APIRouter()
@@ -17,6 +25,7 @@ class MessageResponse(BaseModel):
 
     message: str
     status: str
+
 
 # Include example endpoints
 api_router.include_router(example.router, prefix="/example", tags=["users"])
@@ -37,7 +46,10 @@ api_router.include_router(chat_sessions.router, tags=["chat-sessions"])
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 
 # Include study material generator endpoints
-api_router.include_router(study_materials.router, prefix="/study", tags=["study-materials"])
+api_router.include_router(
+    study_materials.router, prefix="/study", tags=["study-materials"]
+)
+
 
 @api_router.get("/health", response_model=MessageResponse)
 def health_check():

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -18,7 +18,6 @@ class MessageResponse(BaseModel):
     message: str
     status: str
 
-api_router.include_router(study_materials.router, prefix="/study", tags=["study"])
 # Include example endpoints
 api_router.include_router(example.router, prefix="/example", tags=["users"])
 
@@ -37,6 +36,8 @@ api_router.include_router(chat_sessions.router, tags=["chat-sessions"])
 # Include document endpoints
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 
+# Include study material generator endpoints
+api_router.include_router(study_materials.router, prefix="/study", tags=["study-materials"])
 
 @api_router.get("/health", response_model=MessageResponse)
 def health_check():

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -7,7 +7,7 @@ for PostgreSQL/Supabase integration.
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Generator, List, Optional
+from typing import Any, Generator, Optional
 
 import psycopg2
 from psycopg2.extras import RealDictCursor

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -7,7 +7,7 @@ for PostgreSQL/Supabase integration.
 
 import logging
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Any, Generator, List, Optional
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -44,7 +44,7 @@ def init_database_pool(min_connections: int = 1, max_connections: int = 10) -> N
         raise
 
 
-def get_db_connection():
+def get_db_connection() -> psycopg2.extensions.connection:
     """
     Get a database connection from the pool.
 
@@ -71,7 +71,7 @@ def get_db_connection():
         raise
 
 
-def return_db_connection(connection) -> None:
+def return_db_connection(connection: psycopg2.extensions.connection) -> None:
     """
     Return a database connection to the pool.
 
@@ -120,7 +120,7 @@ def get_db() -> Generator[psycopg2.extensions.connection, None, None]:
             return_db_connection(connection)
 
 
-def get_direct_connection():
+def get_direct_connection() -> psycopg2.extensions.connection:
     """
     Get a direct database connection without using the pool.
 
@@ -168,7 +168,7 @@ def test_connection() -> bool:
             cursor = db.cursor()
             cursor.execute("SELECT 1 as test")
             result = cursor.fetchone()
-            success = result and result["test"] == 1
+            success = bool(result and dict(result).get("test") == 1) if result else False
 
         if success:
             logger.info("Database connection test successful")
@@ -185,7 +185,9 @@ def test_connection() -> bool:
 # Helper functions for common database operations
 
 
-def execute_statement(query: str, params=None, fetch_result: bool = False):
+def execute_statement(
+    query: str, params: Optional[tuple] = None, fetch_result: bool = False
+) -> Any:
     """
     Execute a non-SELECT statement (INSERT, UPDATE, DELETE).
 
@@ -215,7 +217,9 @@ def execute_statement(query: str, params=None, fetch_result: bool = False):
         return cursor.rowcount
 
 
-def execute_query(query: str, params=None, fetch_one: bool = False):
+def execute_query(
+    query: str, params: Optional[tuple] = None, fetch_one: bool = False
+) -> Any:
     """
     Execute a query and return results.
 
@@ -248,7 +252,9 @@ def execute_query(query: str, params=None, fetch_one: bool = False):
             return cursor.fetchall()
 
 
-def execute_insert(query: str, params=None, return_id: bool = True):
+def execute_insert(
+    query: str, params: Optional[tuple] = None, return_id: bool = True
+) -> Any:
     """
     Execute an INSERT query and optionally return the inserted ID.
 
@@ -273,7 +279,12 @@ def execute_insert(query: str, params=None, return_id: bool = True):
 
         if return_id:
             result = cursor.fetchone()
-            return result[0] if result else None
+            if result:
+                # RealDictCursor returns dict-like objects, get first value
+                result_dict = dict(result)
+                return next(iter(result_dict.values())) if result_dict else None
+            return None
+        return None
 
 
 # Initialize the connection pool when module is imported

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -168,7 +168,9 @@ def test_connection() -> bool:
             cursor = db.cursor()
             cursor.execute("SELECT 1 as test")
             result = cursor.fetchone()
-            success = bool(result and dict(result).get("test") == 1) if result else False
+            success = (
+                bool(result and dict(result).get("test") == 1) if result else False
+            )
 
         if success:
             logger.info("Database connection test successful")

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, Field
+
+
+

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -1,4 +1,107 @@
+from datetime import datetime
 from pydantic import BaseModel, Field
+from typing import Optional, Literal
+from uuid import UUID
+
+class QuizQuestion(BaseModel):
+    question: str
+    type: Literal["multiple_choice", "multiple_select"]
+    options: list[str]
+    correct_answer: str | list[str] # str for mc, list[str] for ms
+    explanation: Optional[str] = None
+
+class QuizGenerateRequest(BaseModel):
+    piazza_course_id: str
+    title: str = Field(..., min_length=1, max_length=255)
+    difficulty: Literal['easy', 'medium', 'hard']
+    num_questions: int = Field(default=10, ge=1, le=50)
+    source_posts: Optional[list[str]]
 
 
+class QuizSubmitRequest(BaseModel):
+    answers: list[str | list[str]] # ordered, matching questionz by index
 
+class QuizResponse(BaseModel):
+    id: UUID
+    title: str
+    difficulty: str
+    questions: list[QuizQuestion]
+    source_posts: list[str]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class QuizResultResponse(BaseModel):
+    quiz_id: UUID
+    score: float
+    correct_count: int
+    total_count: int
+    completed_at: datetime
+
+class QuizDeleteResponse(BaseModel):
+    id: UUID
+    deleted: bool = True
+    message: str = "Quiz deleted successfully"
+
+
+# ------ Flashcards ------ #
+
+class FlashcardRequestGenerate(BaseModel):
+    piazza_course_id: str
+    title: str = Field(..., min_length=1, max_length=255)
+    tags: Optional[list[str]] = None
+    source_posts: Optional[list[str]] = None
+
+class FlashcardReviewRequest(BaseModel):
+    quality: int = Field(..., ge=0,le=5) # SM-2: 0=blackout, 5=perfect
+
+class FlashcardResponse(BaseModel):
+    id: UUID
+    front: str
+    back: str
+    card_type: str
+    ease_factor: float
+    interval_days: int
+    next_review: datetime
+    review_count: int
+
+    class Config:
+        from_attributes = True
+
+class FlashcardAllResponse(BaseModel):
+    id: UUID
+    title: str
+    tags: Optional[list[str]] = None
+    created_at: datetime
+    cards: list[FlashcardResponse]
+
+    class Config:
+        from_attributes = True
+
+class FlashcardDeleteResponse(BaseModel):
+    id: UUID
+    deleted: bool = True
+    message: str = "Flashcard deck deleted successfully"
+
+class SummaryGenerateRequest(BaseModel):
+    piazza_course_id: str
+    title: str  = Field(..., min_length=1, max_length=255)
+    summary_type: Literal['thread', 'weekly', 'exam_guide', 'custom']
+    source_posts: Optional[list[str]] = None
+
+class SummaryResponse(BaseModel):
+    id: UUID
+    title: str
+    content: str
+    summary_type: Optional[str]
+    source_posts: Optional[list[str]]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class AllStudyMaterialsResponse(BaseModel):
+    quizzes: list[QuizResponse]
+    flashcard_decks: list[FlashcardAllResponse]
+    summaries: list[SummaryResponse]

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -47,6 +47,11 @@ class QuizDeleteResponse(BaseModel):
 
 # ------ Flashcards ------ #
 
+class FlashcardCard(BaseModel):
+    front: str
+    back: str
+    card_type: Literal["concept", "definition", "qa"]
+
 class FlashcardRequestGenerate(BaseModel):
     piazza_course_id: str
     title: str = Field(..., min_length=1, max_length=255)

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -15,7 +15,7 @@ class QuizGenerateRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     difficulty: Literal['easy', 'medium', 'hard']
     num_questions: int = Field(default=10, ge=1, le=50)
-    source_posts: Optional[list[str]]
+    source_posts: Optional[list[str]] = None
 
 
 class QuizSubmitRequest(BaseModel):

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -3,23 +3,26 @@ from pydantic import BaseModel, Field
 from typing import Optional, Literal
 from uuid import UUID
 
+
 class QuizQuestion(BaseModel):
     question: str
     type: Literal["multiple_choice", "multiple_select"]
     options: list[str]
-    correct_answer: str | list[str] # str for mc, list[str] for ms
+    correct_answer: str | list[str]  # str for mc, list[str] for ms
     explanation: Optional[str] = None
+
 
 class QuizGenerateRequest(BaseModel):
     piazza_course_id: str
     title: str = Field(..., min_length=1, max_length=255)
-    difficulty: Literal['easy', 'medium', 'hard']
+    difficulty: Literal["easy", "medium", "hard"]
     num_questions: int = Field(default=10, ge=1, le=50)
     source_posts: Optional[list[str]] = None
 
 
 class QuizSubmitRequest(BaseModel):
-    answers: list[str | list[str]] # ordered, matching questionz by index
+    answers: list[str | list[str]]  # ordered, matching questionz by index
+
 
 class QuizResponse(BaseModel):
     id: UUID
@@ -32,12 +35,14 @@ class QuizResponse(BaseModel):
     class Config:
         from_attributes = True
 
+
 class QuizResultResponse(BaseModel):
     quiz_id: UUID
     score: float
     correct_count: int
     total_count: int
     completed_at: datetime
+
 
 class QuizDeleteResponse(BaseModel):
     id: UUID
@@ -47,10 +52,12 @@ class QuizDeleteResponse(BaseModel):
 
 # ------ Flashcards ------ #
 
+
 class FlashcardCard(BaseModel):
     front: str
     back: str
     card_type: Literal["concept", "definition", "qa"]
+
 
 class FlashcardRequestGenerate(BaseModel):
     piazza_course_id: str
@@ -58,8 +65,10 @@ class FlashcardRequestGenerate(BaseModel):
     tags: Optional[list[str]] = None
     source_posts: Optional[list[str]] = None
 
+
 class FlashcardReviewRequest(BaseModel):
-    quality: int = Field(..., ge=0,le=5) # SM-2: 0=blackout, 5=perfect
+    quality: int = Field(..., ge=0, le=5)  # SM-2: 0=blackout, 5=perfect
+
 
 class FlashcardResponse(BaseModel):
     id: UUID
@@ -74,6 +83,7 @@ class FlashcardResponse(BaseModel):
     class Config:
         from_attributes = True
 
+
 class FlashcardAllResponse(BaseModel):
     id: UUID
     title: str
@@ -84,16 +94,19 @@ class FlashcardAllResponse(BaseModel):
     class Config:
         from_attributes = True
 
+
 class FlashcardDeleteResponse(BaseModel):
     id: UUID
     deleted: bool = True
     message: str = "Flashcard deck deleted successfully"
 
+
 class SummaryGenerateRequest(BaseModel):
     piazza_course_id: str
-    title: str  = Field(..., min_length=1, max_length=255)
-    summary_type: Literal['thread', 'weekly', 'exam_guide', 'custom']
+    title: str = Field(..., min_length=1, max_length=255)
+    summary_type: Literal["thread", "weekly", "exam_guide", "custom"]
     source_posts: Optional[list[str]] = None
+
 
 class SummaryResponse(BaseModel):
     id: UUID
@@ -105,6 +118,7 @@ class SummaryResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
 
 class AllStudyMaterialsResponse(BaseModel):
     quizzes: list[QuizResponse]

--- a/backend/app/models/study_materials.py
+++ b/backend/app/models/study_materials.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from pydantic import BaseModel, Field
-from typing import Optional, Literal
+from typing import Literal, Optional
 from uuid import UUID
+
+from pydantic import BaseModel, Field
 
 
 class QuizQuestion(BaseModel):

--- a/backend/app/textGeneration/__init__.py
+++ b/backend/app/textGeneration/__init__.py
@@ -3,6 +3,16 @@ Text Generation Module
 """
 
 from app.textGeneration.llm_service import get_llm_response, stream_llm_response
-from app.textGeneration.study_generator import generate_quiz_questions, generate_flashcard_stream, generate_summary
+from app.textGeneration.study_generator import (
+    generate_quiz_questions,
+    generate_flashcard_stream,
+    generate_summary,
+)
 
-__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions", "generate_flashcard_stream", "generate_summary"]
+__all__ = [
+    "get_llm_response",
+    "stream_llm_response",
+    "generate_quiz_questions",
+    "generate_flashcard_stream",
+    "generate_summary",
+]

--- a/backend/app/textGeneration/__init__.py
+++ b/backend/app/textGeneration/__init__.py
@@ -3,6 +3,6 @@ Text Generation Module
 """
 
 from app.textGeneration.llm_service import get_llm_response, stream_llm_response
-from app.textGeneration.study_generator import generate_quiz_questions
+from app.textGeneration.study_generator import generate_quiz_questions, generate_flashcard_stream, generate_summary
 
-__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions"]
+__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions", "generate_flashcard_stream", "generate_summary"]

--- a/backend/app/textGeneration/__init__.py
+++ b/backend/app/textGeneration/__init__.py
@@ -4,8 +4,8 @@ Text Generation Module
 
 from app.textGeneration.llm_service import get_llm_response, stream_llm_response
 from app.textGeneration.study_generator import (
-    generate_quiz_questions,
     generate_flashcard_stream,
+    generate_quiz_questions,
     generate_summary,
 )
 

--- a/backend/app/textGeneration/__init__.py
+++ b/backend/app/textGeneration/__init__.py
@@ -3,5 +3,6 @@ Text Generation Module
 """
 
 from app.textGeneration.llm_service import get_llm_response, stream_llm_response
+from app.textGeneration.study_generator import generate_quiz_questions
 
-__all__ = ["get_llm_response", "stream_llm_response"]
+__all__ = ["get_llm_response", "stream_llm_response", "generate_quiz_questions"]

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -1,0 +1,201 @@
+import json
+import logging
+from typing import Any, Optional
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_groq import ChatGroq
+
+from app.core.database import execute_query
+from app.models.study_materials import QuizQuestion
+
+logger = logging.getLogger(__name__)
+
+QUIZ_MODEL = "openai/gpt-oss-120b"
+
+
+class QuizGenerationPayload(BaseModel):
+    questions: list[QuizQuestion]
+
+
+_quiz_payload_adapter = TypeAdapter(QuizGenerationPayload)
+_questions_schema_json = json.dumps(_quiz_payload_adapter.json_schema(), indent=2)
+
+
+def _extract_json_object(raw: str) -> dict[str, Any]:
+    """Extract a JSON object from raw model output, including fenced blocks."""
+    cleaned = raw.strip()
+
+    if cleaned.startswith("```"):
+        cleaned = cleaned.removeprefix("```json").removeprefix("```").strip()
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3].strip()
+
+    try:
+        parsed = json.loads(cleaned)
+        if isinstance(parsed, dict):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return json.loads(cleaned[start : end + 1])
+
+    raise ValueError("LLM did not return a valid JSON object.")
+
+
+def _get_answered_chunks(
+    piazza_course_id: str,
+    source_posts: Optional[list[str]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch ingested chunks for a course where answer metadata indicates a resolved post.
+    Data comes from langchain_pg_embedding/cmetadata.
+    """
+    base_query = """
+        SELECT e.document, e.cmetadata
+        FROM langchain_pg_embedding e
+        JOIN langchain_pg_collection c ON e.collection_id = c.uuid
+        WHERE c.name = %s
+          AND (
+            COALESCE((e.cmetadata->>'has_instructor_answer')::boolean, false) = true
+            OR COALESCE((e.cmetadata->>'has_student_answer')::boolean, false) = true
+          )
+    """
+    params: list[Any] = [piazza_course_id]
+
+    if source_posts:
+        base_query += " AND (e.cmetadata->>'post_number') = ANY(%s)"
+        params.append(source_posts)
+
+    base_query += """
+        ORDER BY
+          CASE
+            WHEN (e.cmetadata->>'post_number') ~ '^[0-9]+$'
+              THEN (e.cmetadata->>'post_number')::int
+            ELSE 0
+          END DESC,
+          e.id DESC
+        LIMIT %s
+    """
+    params.append(limit)
+
+    rows = execute_query(base_query, tuple(params))
+    return rows or []
+
+
+def _build_context(chunks: list[dict[str, Any]]) -> tuple[str, list[str]]:
+    """Create LLM context text and source post list from embedding rows."""
+    context_blocks: list[str] = []
+    source_posts: list[str] = []
+    seen_posts: set[str] = set()
+
+    for idx, row in enumerate(chunks, 1):
+        metadata = row.get("cmetadata") or {}
+        post_number = metadata.get("post_number")
+        post_str = str(post_number) if post_number is not None else "unknown"
+        text = row.get("document") or ""
+
+        if post_str not in seen_posts:
+            seen_posts.add(post_str)
+            source_posts.append(post_str)
+
+        context_blocks.append(f"[Post {post_str} | Chunk {idx}]\n{text}")
+
+    return "\n\n".join(context_blocks), source_posts
+
+
+def generate_quiz_questions(
+    *,
+    piazza_course_id: str,
+    title: str,
+    difficulty: str,
+    num_questions: int,
+    source_posts: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """
+    Generate quiz questions from ingested answered posts.
+
+    Returns:
+        {
+            "questions": list[dict],
+            "source_posts": list[str],
+            "model": str
+        }
+    """
+    chunks = _get_answered_chunks(
+        piazza_course_id=piazza_course_id,
+        source_posts=source_posts,
+        limit=max(num_questions * 6, 20),
+    )
+    if not chunks:
+        raise ValueError(
+            "No answered ingested posts found for this course. Run ingestion first."
+        )
+
+    context, resolved_source_posts = _build_context(chunks)
+
+    llm = ChatGroq(
+        model=QUIZ_MODEL,
+        temperature=0.2,
+        max_tokens=6000,
+        max_retries=3,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are generating course quizzes from Piazza context.
+Return strict JSON only. No markdown, no prose.
+Your output must conform to this Pydantic JSON schema (for `questions` only):
+{quiz_questions_schema}
+Output envelope must be:
+{{"questions": [...]}}
+Rules:
+- Generate exactly {num_questions} questions.
+- Questions must be grounded in provided context.
+- For multiple_choice, correct_answer must be a single string present in options.
+- For multiple_select, correct_answer must be a non-empty list of strings all present in options.
+- 4 options per question.
+- Difficulty level: {difficulty}.
+- Quiz title: {title}.
+""",
+            ),
+            ("human", "Context:\n{context}"),
+        ]
+    )
+
+    raw = (prompt | llm | StrOutputParser()).invoke(
+        {
+            "num_questions": num_questions,
+            "difficulty": difficulty,
+            "title": title,
+            "context": context,
+            "quiz_questions_schema": _questions_schema_json,
+        }
+    )
+
+    parsed = _extract_json_object(raw)
+
+    try:
+        payload = _quiz_payload_adapter.validate_python(parsed)
+        questions = payload.questions
+    except ValidationError as e:
+        logger.error("Quiz question validation failed: %s", e)
+        raise ValueError("Generated quiz format is invalid.")
+
+    if len(questions) != num_questions:
+        raise ValueError(
+            f"Generated {len(questions)} questions, expected {num_questions}."
+        )
+
+    return {
+        "questions": [q.model_dump() for q in questions],
+        "source_posts": resolved_source_posts,
+        "model": QUIZ_MODEL,
+    }

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -141,7 +141,7 @@ def generate_quiz_questions(
     chunks = _get_answered_chunks(
         piazza_course_id=piazza_course_id,
         source_posts=source_posts,
-        limit=max(num_questions * 6, 20),
+        limit=min(num_questions * 3, 30),
     )
     if not chunks:
         raise ValueError(
@@ -175,6 +175,9 @@ Rules:
 - 4 options per question.
 - Difficulty level: {difficulty}.
 - Quiz title: {title}.
+- Focus exclusively on course concepts, definitions, algorithms, theories, and technical subject matter.
+- NEVER generate questions about: grade curves or curve amounts, score adjustments or extra credit, exam/assignment score averages or statistics, grading scales or cutoffs, rounding policies, late penalties or extensions, exam logistics (time, location, format, duration), regrade or grading dispute discussions, or any other administrative/logistical announcements.
+- If a piece of context only contains administrative or grade-related information and no educational content, skip it entirely and draw from other context.
 """,
             ),
             ("human", "Context:\n{context}"),
@@ -210,6 +213,7 @@ Rules:
         "source_posts": resolved_source_posts,
         "model": QUIZ_MODEL,
     }
+
 
 
 def generate_summary(
@@ -277,6 +281,7 @@ Write a clear, well-structured prose summary. Do not return JSON.
 Summary type: {summary_type}
 Instructions: {type_instruction}
 Title: {title}
+Focus only on course content and educational material. Ignore posts about grades, exam logistics, grading disputes, assignment deadlines, or software/homework bugs unrelated to learning.
 """,
             ),
             ("human", "Context:\n{context}"),
@@ -351,6 +356,9 @@ Rules:
 - front: a concise question or term.
 - back: a clear, complete answer or explanation.
 - Deck title: {title}.
+- Focus exclusively on course concepts, definitions, algorithms, theories, and technical subject matter.
+- NEVER create flashcards about: grade curves or curve amounts, score adjustments or extra credit, exam/assignment score averages or statistics, grading scales or cutoffs, rounding policies, late penalties or extensions, exam logistics (time, location, format, duration), regrade or grading dispute discussions, or any other administrative/logistical announcements.
+- If a piece of context only contains administrative or grade-related information and no educational content, skip it entirely and draw from other context.
 {tags_instruction}""",
             ),
             ("human", "Context:\n{context}"),

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -16,6 +16,7 @@ QUIZ_MODEL = "openai/gpt-oss-120b"
 
 # ----------------------------- Quiz ------------------------------- #
 
+
 class QuizGenerationPayload(BaseModel):
     questions: list[QuizQuestion]
 
@@ -25,6 +26,7 @@ _questions_schema_json = json.dumps(_quiz_payload_adapter.json_schema(), indent=
 
 
 # ----------------------------- Flashcards ------------------------------- #
+
 
 class FlashcardGenerationPayload(BaseModel):
     cards: list[FlashcardCard]
@@ -214,7 +216,6 @@ Rules:
         "source_posts": resolved_source_posts,
         "model": QUIZ_MODEL,
     }
-
 
 
 def generate_summary(

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -2,10 +2,10 @@ import json
 import logging
 from typing import Any, Optional
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_groq import ChatGroq
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from app.core.database import execute_query
 from app.models.study_materials import FlashcardCard, QuizQuestion

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -8,12 +8,13 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_groq import ChatGroq
 
 from app.core.database import execute_query
-from app.models.study_materials import QuizQuestion
+from app.models.study_materials import FlashcardCard, QuizQuestion
 
 logger = logging.getLogger(__name__)
 
 QUIZ_MODEL = "openai/gpt-oss-120b"
 
+# ----------------------------- Quiz ------------------------------- #
 
 class QuizGenerationPayload(BaseModel):
     questions: list[QuizQuestion]
@@ -21,6 +22,16 @@ class QuizGenerationPayload(BaseModel):
 
 _quiz_payload_adapter = TypeAdapter(QuizGenerationPayload)
 _questions_schema_json = json.dumps(_quiz_payload_adapter.json_schema(), indent=2)
+
+
+# ----------------------------- Flashcards ------------------------------- #
+
+class FlashcardGenerationPayload(BaseModel):
+    cards: list[FlashcardCard]
+
+
+_flashcard_payload_adapter = TypeAdapter(FlashcardGenerationPayload)
+_flashcard_schema_json = json.dumps(_flashcard_payload_adapter.json_schema(), indent=2)
 
 
 def _extract_json_object(raw: str) -> dict[str, Any]:
@@ -196,6 +207,180 @@ Rules:
 
     return {
         "questions": [q.model_dump() for q in questions],
+        "source_posts": resolved_source_posts,
+        "model": QUIZ_MODEL,
+    }
+
+
+def generate_summary(
+    *,
+    piazza_course_id: str,
+    title: str,
+    summary_type: str,
+    source_posts: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """
+    Generate a prose summary from ingested answered posts.
+
+    Returns:
+        {
+            "content": str,
+            "source_posts": list[str],
+            "model": str
+        }
+    """
+    chunks = _get_answered_chunks(
+        piazza_course_id=piazza_course_id,
+        source_posts=source_posts,
+        limit=30,
+    )
+    if not chunks:
+        raise ValueError(
+            "No answered ingested posts found for this course. Run ingestion first."
+        )
+
+    context, resolved_source_posts = _build_context(chunks)
+
+    type_instructions = {
+        "thread": (
+            "Summarize the specific thread(s) provided. "
+            "Use a concise Q&A format: state the question(s) raised and the key answer(s) given."
+        ),
+        "weekly": (
+            "Write a weekly digest of all activity. "
+            "Organize by topic/theme. Briefly describe the main questions and resolutions."
+        ),
+        "exam_guide": (
+            "Create an exam study guide. "
+            "List key concepts, important definitions, and common question patterns found in the posts."
+        ),
+        "custom": (
+            "Write a comprehensive summary of the provided content. "
+            "Cover all major topics and important points."
+        ),
+    }
+    type_instruction = type_instructions.get(summary_type, type_instructions["custom"])
+
+    llm = ChatGroq(
+        model=QUIZ_MODEL,
+        temperature=0.3,
+        max_tokens=4000,
+        max_retries=3,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are summarizing Piazza course discussion posts for students.
+Write a clear, well-structured prose summary. Do not return JSON.
+Summary type: {summary_type}
+Instructions: {type_instruction}
+Title: {title}
+""",
+            ),
+            ("human", "Context:\n{context}"),
+        ]
+    )
+
+    content = (prompt | llm | StrOutputParser()).invoke(
+        {
+            "summary_type": summary_type,
+            "type_instruction": type_instruction,
+            "title": title,
+            "context": context,
+        }
+    )
+
+    if not content or not content.strip():
+        raise ValueError("LLM returned an empty summary.")
+
+    return {
+        "content": content.strip(),
+        "source_posts": resolved_source_posts,
+        "model": QUIZ_MODEL,
+    }
+
+
+def generate_flashcard_stream(
+    piazza_course_id: str,
+    title: str,
+    tags: Optional[list[str]],
+    source_posts: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """
+    Generate flashcards from ingested answered posts.
+
+    Returns:
+        {
+            "cards": list[dict],
+            "source_posts": list[str],
+            "model": str
+        }
+    """
+    chunks = _get_answered_chunks(piazza_course_id, source_posts, 20)
+
+    if not chunks:
+        raise ValueError(
+            "No answered ingested posts found for this course. Run ingestion first."
+        )
+
+    context, resolved_source_posts = _build_context(chunks)
+
+    llm = ChatGroq(
+        model=QUIZ_MODEL,
+        temperature=0.2,
+        max_tokens=6000,
+        max_retries=3,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are generating course flashcards from Piazza context.
+Return strict JSON only. No markdown, no prose.
+Your output must conform to this Pydantic JSON schema (for `cards` only):
+{flashcard_schema}
+Output envelope must be:
+{{"cards": [...]}}
+Rules:
+- Generate between 10 and 20 flashcards depending on available context.
+- Each card must be grounded in the provided context.
+- card_type must be one of: "concept", "definition", "qa".
+- front: a concise question or term.
+- back: a clear, complete answer or explanation.
+- Deck title: {title}.
+{tags_instruction}""",
+            ),
+            ("human", "Context:\n{context}"),
+        ]
+    )
+
+    tags_instruction = (
+        f"- Focus on these topic tags: {', '.join(tags)}." if tags else ""
+    )
+
+    raw = (prompt | llm | StrOutputParser()).invoke(
+        {
+            "flashcard_schema": _flashcard_schema_json,
+            "title": title,
+            "tags_instruction": tags_instruction,
+            "context": context,
+        }
+    )
+
+    parsed = _extract_json_object(raw)
+
+    try:
+        payload = _flashcard_payload_adapter.validate_python(parsed)
+        cards = payload.cards
+    except ValidationError as e:
+        logger.error("Flashcard validation failed: %s", e)
+        raise ValueError("Generated flashcard format is invalid.")
+
+    return {
+        "cards": [c.model_dump() for c in cards],
         "source_posts": resolved_source_posts,
         "model": QUIZ_MODEL,
     }

--- a/backend/app/textGeneration/study_generator.py
+++ b/backend/app/textGeneration/study_generator.py
@@ -175,6 +175,7 @@ Rules:
 - 4 options per question.
 - Difficulty level: {difficulty}.
 - Quiz title: {title}.
+- Every question MUST include a non-empty explanation field (1-3 sentences) that explains why the correct answer is right, referencing the relevant concept from the context.
 - Focus exclusively on course concepts, definitions, algorithms, theories, and technical subject matter.
 - NEVER generate questions about: grade curves or curve amounts, score adjustments or extra credit, exam/assignment score averages or statistics, grading scales or cutoffs, rounding policies, late penalties or extensions, exam logistics (time, location, format, duration), regrade or grading dispute discussions, or any other administrative/logistical announcements.
 - If a piece of context only contains administrative or grade-related information and no educational content, skip it entirely and draw from other context.

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,4 +49,6 @@ if __name__ == "__main__":
         host=settings.HOST,  # ✅ Use config!
         port=settings.PORT,  # ✅ Use config!
         reload=settings.DEBUG,  # ✅ Use config!
+        log_level="info",
+        access_log=True,
     )

--- a/docs/STUDY_MATERIALS_DESIGN.md
+++ b/docs/STUDY_MATERIALS_DESIGN.md
@@ -5,7 +5,7 @@
 The Study Material Generator extends ThreadSense to automatically create educational content (quizzes, flashcards, and summaries) from Piazza course materials using LLM technology.
 
 ### Key Features
-- **Quiz Generation**: Multiple-choice and short-answer questions with auto-grading
+- **Quiz Generation**: Multiple-choice and multiple-select questions with auto-grading
 - **Flashcard Decks**: Spaced repetition system using SM-2 algorithm
 - **Summaries**: Condensed thread summaries and exam guides
 - **Progress Tracking**: Quiz scores and flashcard mastery metrics
@@ -248,7 +248,7 @@ FOR EACH ROW EXECUTE FUNCTION update_deck_card_count();
 
 4. **`grade_quiz_submission(questions, answers)`**
    - Multiple choice: exact match
-   - Short answer: keyword matching
+   - Multiple select: check all correct options selected
    - Return score + detailed feedback
 
 5. **`update_flashcard_sm2(ease_factor, interval_days, repetitions, quality)`**

--- a/docs/STUDY_MATERIALS_DESIGN.md
+++ b/docs/STUDY_MATERIALS_DESIGN.md
@@ -1,0 +1,402 @@
+# Study Material Generator - Design Document
+
+## Overview
+
+The Study Material Generator extends ThreadSense to automatically create educational content (quizzes, flashcards, and summaries) from Piazza course materials using LLM technology.
+
+### Key Features
+- **Quiz Generation**: Multiple-choice and short-answer questions with auto-grading
+- **Flashcard Decks**: Spaced repetition system using SM-2 algorithm
+- **Summaries**: Condensed thread summaries and exam guides
+- **Progress Tracking**: Quiz scores and flashcard mastery metrics
+
+---
+
+## Architecture
+
+### Design Decisions
+
+**Following Existing Patterns:**
+- New router: `app/api/endpoints/study_materials.py`
+- LLM service: `app/textGeneration/study_generator.py`
+- Models: `app/models/study_materials.py`
+- Reuse existing: vector store (PGVector), authentication, database pooling, streaming responses
+
+**Tech Stack:**
+- Backend: FastAPI + LangChain + Groq/OpenAI (existing)
+- Database: PostgreSQL (Supabase) with new tables
+- Frontend: React component in popup + content script integration
+- LLM: `openai/gpt-oss-120b` for generation, OpenAI embeddings for retrieval
+
+**Data Flow:**
+```
+User Request → API Endpoint → Vector Store Retrieval → LLM Generation (streaming) → Save to DB → Return to Frontend
+```
+
+---
+
+## Database Schema
+
+### Migration: `supabase/migrations/YYYYMMDD_create_study_materials.sql`
+
+```sql
+-- Quizzes
+CREATE TABLE quizzes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    piazza_course_id VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
+    difficulty TEXT CHECK (difficulty IN ('easy', 'medium', 'hard')) NOT NULL,
+    questions JSONB NOT NULL,  -- [{id, question, type, options[], correct_answer, explanation, points}]
+    source_posts TEXT[],
+    tags TEXT[],
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_quizzes_user_id ON quizzes(user_id);
+CREATE INDEX idx_quizzes_thread_id ON quizzes(thread_id);
+CREATE INDEX idx_quizzes_piazza_course_id ON quizzes(piazza_course_id);
+
+-- Quiz Attempts
+CREATE TABLE quiz_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    quiz_id UUID NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    answers JSONB NOT NULL,  -- [{question_id, user_answer, is_correct, points_earned}]
+    score DECIMAL(5,2) NOT NULL,
+    time_spent_seconds INT,
+    completed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_quiz_attempts_quiz_id ON quiz_attempts(quiz_id);
+CREATE INDEX idx_quiz_attempts_user_id ON quiz_attempts(user_id);
+
+-- Flashcard Decks
+CREATE TABLE flashcard_decks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    piazza_course_id VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    tags TEXT[],
+    total_cards INT DEFAULT 0,
+    mastered_cards INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_flashcard_decks_user_id ON flashcard_decks(user_id);
+CREATE INDEX idx_flashcard_decks_thread_id ON flashcard_decks(thread_id);
+
+-- Flashcards
+CREATE TABLE flashcards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deck_id UUID NOT NULL REFERENCES flashcard_decks(id) ON DELETE CASCADE,
+    front TEXT NOT NULL,
+    back TEXT NOT NULL,
+    card_type TEXT DEFAULT 'basic' CHECK (card_type IN ('basic', 'cloze')),
+    source_post TEXT,
+    -- SM-2 Algorithm fields
+    ease_factor DECIMAL(3,2) DEFAULT 2.5,
+    interval_days INT DEFAULT 0,
+    repetitions INT DEFAULT 0,
+    next_review TIMESTAMPTZ DEFAULT NOW(),
+    last_reviewed TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_flashcards_deck_id ON flashcards(deck_id);
+CREATE INDEX idx_flashcards_next_review ON flashcards(next_review);
+
+-- Flashcard Reviews (for progress tracking)
+CREATE TABLE flashcard_reviews (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    flashcard_id UUID NOT NULL REFERENCES flashcards(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    quality INT NOT NULL CHECK (quality BETWEEN 0 AND 5),  -- SM-2 quality rating
+    reviewed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_flashcard_reviews_flashcard_id ON flashcard_reviews(flashcard_id);
+
+-- Summaries
+CREATE TABLE summaries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    piazza_course_id VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,  -- Markdown-formatted
+    summary_type TEXT CHECK (summary_type IN ('thread', 'weekly', 'exam_guide', 'custom')),
+    source_posts TEXT[],
+    tags TEXT[],
+    word_count INT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_summaries_user_id ON summaries(user_id);
+CREATE INDEX idx_summaries_thread_id ON summaries(thread_id);
+CREATE INDEX idx_summaries_summary_type ON summaries(summary_type);
+
+-- Auto-update triggers
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_quizzes_updated_at BEFORE UPDATE ON quizzes
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trigger_flashcard_decks_updated_at BEFORE UPDATE ON flashcard_decks
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trigger_summaries_updated_at BEFORE UPDATE ON summaries
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- Auto-update deck card counts
+CREATE OR REPLACE FUNCTION update_deck_card_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        UPDATE flashcard_decks SET total_cards = total_cards + 1, updated_at = NOW()
+        WHERE id = NEW.deck_id;
+    ELSIF TG_OP = 'DELETE' THEN
+        UPDATE flashcard_decks SET total_cards = GREATEST(total_cards - 1, 0), updated_at = NOW()
+        WHERE id = OLD.deck_id;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_deck_card_count
+AFTER INSERT OR DELETE ON flashcards
+FOR EACH ROW EXECUTE FUNCTION update_deck_card_count();
+```
+
+---
+
+## Backend API Design
+
+### Endpoints: `app/api/endpoints/study_materials.py`
+
+**Quiz Endpoints:**
+- `POST /study/quiz/generate` - Generate quiz (streaming NDJSON)
+- `GET /study/quiz/{quiz_id}` - Get quiz details
+- `POST /study/quiz/{quiz_id}/submit` - Submit answers, get score
+- `GET /study/quiz` - List all user quizzes (filterable)
+- `DELETE /study/quiz/{quiz_id}` - Delete quiz
+
+**Flashcard Endpoints:**
+- `POST /study/flashcards/generate` - Generate deck (streaming)
+- `GET /study/flashcards/{deck_id}` - Get deck with all cards
+- `PUT /study/flashcards/{card_id}/review` - Submit review (updates SM-2)
+- `GET /study/flashcards/{deck_id}/due` - Get cards due for review
+- `GET /study/flashcards` - List all decks
+- `DELETE /study/flashcards/{deck_id}` - Delete deck
+
+**Summary Endpoints:**
+- `POST /study/summary/generate` - Generate summary (streaming)
+- `GET /study/summary/{summary_id}` - Get summary
+- `GET /study/summary` - List all summaries
+- `DELETE /study/summary/{summary_id}` - Delete summary
+
+**Combined:**
+- `GET /study/materials` - List all materials (quizzes, decks, summaries)
+
+### Request/Response Pattern
+- All endpoints require `Authorization: Bearer <token>`
+- Generation endpoints return **NDJSON streams**:
+  ```json
+  {"type": "progress", "message": "Retrieving content..."}
+  {"type": "question", "question": {...}, "index": 1, "total": 10}
+  {"type": "complete", "quiz_id": "uuid", "num_questions": 10}
+  ```
+
+---
+
+## LLM Orchestration
+
+### Service: `app/textGeneration/study_generator.py`
+
+**Core Functions:**
+
+1. **`generate_quiz_stream(quiz_data, user_id)`**
+   - Retrieve context from vector store (thread_id collection)
+   - Use LangChain prompt template with difficulty + context
+   - Generate JSON-structured questions via LLM
+   - Stream progress updates
+   - Save to `quizzes` table
+
+2. **`generate_flashcards_stream(deck_data, user_id)`**
+   - Retrieve key concepts from vector store
+   - Generate front/back pairs (basic or cloze)
+   - Stream each card as generated
+   - Save deck + cards to database
+
+3. **`generate_summary_stream(summary_data, user_id)`**
+   - Retrieve comprehensive context (10-20 docs)
+   - Generate markdown-formatted summary
+   - Stream content chunks
+   - Save to `summaries` table
+
+4. **`grade_quiz_submission(questions, answers)`**
+   - Multiple choice: exact match
+   - Short answer: keyword matching
+   - Return score + detailed feedback
+
+5. **`update_flashcard_sm2(ease_factor, interval_days, repetitions, quality)`**
+   - SM-2 spaced repetition algorithm
+   - Quality 0-5 → new interval, ease factor, repetitions
+   - Return updated parameters
+
+### Prompting Strategy
+
+**Quiz Generation:**
+```
+System: "You are an expert educational content creator. Generate {num_questions}
+quiz questions at {difficulty} difficulty from the provided Piazza context.
+Include clear questions, realistic options, and detailed explanations."
+
+Context: {retrieved_docs}
+```
+
+**Flashcard Generation:**
+```
+System: "Create {num_cards} flashcards. Front: short prompt. Back: concise answer.
+Focus on definitions, concepts, formulas. Use cloze deletion where appropriate."
+
+Context: {retrieved_docs}
+```
+
+**Summary Generation:**
+```
+System: "Generate a {length} {summary_type} summary in Markdown. Include headings,
+bullet points, and bold key terms. Prioritize core concepts and common questions."
+
+Context: {retrieved_docs}
+```
+
+---
+
+## Frontend Design
+
+### New Component: `src/popup/StudyMaterialsPage.jsx`
+
+**Structure:**
+```
+StudyMaterialsPage
+├── Tab Navigation (Quizzes | Flashcards | Summaries)
+├── Generate Button → Opens dialog with config
+├── Materials List → Cards showing each material
+└── Material Viewer → Quiz player / Flashcard player / Summary viewer
+```
+
+**Key Features:**
+- **Generation Dialog**: Title, difficulty/length, num questions/cards, tags
+- **Streaming UI**: Progress messages during generation
+- **Quiz Player**: Question navigation, answer input, submit, view results with explanations
+- **Flashcard Player**: Card flip animation, SM-2 quality buttons (Again/Hard/Good/Easy)
+- **Summary Viewer**: Markdown rendering with KaTeX for math
+
+**State Management:**
+- Fetch all materials on mount
+- Handle streaming responses with `fetch().body.getReader()`
+- Update UI progressively as content generates
+
+### Content Script Integration: `src/content/content.js`
+
+**Features:**
+- Inject "📚 Generate Study Materials" button on Piazza thread pages
+- Button opens popup to Study Materials tab
+- Quick-generate options (e.g., "Summarize this thread")
+
+---
+
+## Implementation Plan
+
+### Phase 1: Database & API Structure (Week 1)
+- Create migration, run on dev database
+- Build Pydantic models (`app/models/study_materials.py`)
+- Create router file with endpoint stubs
+- Test basic CRUD (no LLM yet)
+
+### Phase 2: LLM Integration (Week 2)
+- Implement `study_generator.py` with all generation functions
+- Add streaming logic
+- Integrate vector store retrieval
+- Implement grading and SM-2 algorithm
+
+### Phase 3: Frontend Core (Week 3)
+- Build `StudyMaterialsPage` component
+- Add tab navigation and material listing
+- Create generation dialogs
+- Implement streaming UI updates
+
+### Phase 4: Interactive Features (Week 4)
+- Build quiz player with submission/grading
+- Build flashcard player with SM-2 review
+- Add summary viewer with markdown rendering
+- Test end-to-end flows
+
+### Phase 5: Content Script + Polish (Week 5)
+- Inject buttons on Piazza pages
+- Add quick-generate flows
+- Bug fixes and UX improvements
+- Documentation
+
+---
+
+## Key Technical Considerations
+
+### Security
+- All endpoints require authentication
+- Users only access their own materials (verified via `user_id`)
+- Input validation via Pydantic
+- Parameterized SQL queries (no injection risk)
+
+### Performance
+- Database indexes on all foreign keys and query fields
+- Cached counts updated via triggers
+- Streaming responses for better UX
+- Reuse existing connection pooling
+
+### SM-2 Spaced Repetition Algorithm
+```
+if quality >= 3 (correct):
+    if repetitions == 0: interval = 1 day
+    if repetitions == 1: interval = 6 days
+    else: interval = previous_interval * ease_factor
+    repetitions++
+else (incorrect):
+    repetitions = 0, interval = 1 day
+
+ease_factor = ease_factor + (0.1 - (5-quality) * (0.08 + (5-quality) * 0.02))
+ease_factor = max(1.3, ease_factor)
+```
+
+---
+
+## Success Metrics
+- Users generate at least 1 study material per week
+- 80%+ quiz completion rate
+- 60%+ flashcard review engagement
+- Positive feedback on content quality
+
+---
+
+**Next Steps:**
+1. Review design with team
+2. Create GitHub issues for each phase
+3. Begin Phase 1 implementation
+
+---
+
+**Version:** 1.0
+**Last Updated:** 2026-02-06

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -87,7 +87,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2881,7 +2880,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2908,7 +2906,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3306,7 +3303,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3885,7 +3881,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
       "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7634,7 +7631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8068,7 +8064,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8551,7 +8546,6 @@
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -9578,7 +9572,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9658,8 +9651,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -10023,7 +10015,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10073,7 +10064,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "babel-loader": "^10.0.0",
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^7.1.2",
+        "dotenv": "^17.2.3",
         "file": "^0.2.2",
         "html-webpack-plugin": "^5.6.4",
         "loader": "^2.1.1",
@@ -3172,24 +3173,24 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -3206,12 +3207,43 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
@@ -4100,9 +4132,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
-      "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4445,22 +4478,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5939,9 +5956,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7943,13 +7960,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -8000,17 +8017,48 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "babel-loader": "^10.0.0",
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.2",
+    "dotenv": "^17.2.3",
     "file": "^0.2.2",
     "html-webpack-plugin": "^5.6.4",
     "loader": "^2.1.1",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -32,5 +32,11 @@
     "service_worker": "background.js"
   },
   "permissions": ["activeTab", "storage", "cookies"],
-  "host_permissions": ["https://piazza.com/*", "http://localhost:8000/*"]
+  "host_permissions": ["https://piazza.com/*", "http://localhost:8000/*"],
+  "web_accessible_resources": [
+    {
+      "resources": ["studytab.html"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/frontend/src/popup/App.jsx
+++ b/frontend/src/popup/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import LoginPage from "./LoginPage";
 import DashboardPage from "./DashboardPage";
 import AssistantPage from "./AssistantPage";
+import StudyMaterialsPage from "./StudyMaterialsPage";
 
 /* global chrome */
 export default function App() {
@@ -175,9 +176,16 @@ export default function App() {
             user={user}
             onLogout={handleLogout}
             onNavigateToAssistant={() => setCurrentPage("assistant")}
+            onNavigateToStudy={() => setCurrentPage("study")}
+          />
+        ) : currentPage === "assistant" ? (
+          <AssistantPage
+            user={user}
+            onBack={() => setCurrentPage("dashboard")}
+            onLogout={handleLogout}
           />
         ) : (
-          <AssistantPage
+          <StudyMaterialsPage
             user={user}
             onBack={() => setCurrentPage("dashboard")}
             onLogout={handleLogout}

--- a/frontend/src/popup/App.jsx
+++ b/frontend/src/popup/App.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import LoginPage from "./LoginPage";
 import DashboardPage from "./DashboardPage";
 import AssistantPage from "./AssistantPage";
-import StudyMaterialsPage from "./StudyMaterialsPage";
 
 /* global chrome */
 export default function App() {
@@ -176,16 +175,9 @@ export default function App() {
             user={user}
             onLogout={handleLogout}
             onNavigateToAssistant={() => setCurrentPage("assistant")}
-            onNavigateToStudy={() => setCurrentPage("study")}
-          />
-        ) : currentPage === "assistant" ? (
-          <AssistantPage
-            user={user}
-            onBack={() => setCurrentPage("dashboard")}
-            onLogout={handleLogout}
           />
         ) : (
-          <StudyMaterialsPage
+          <AssistantPage
             user={user}
             onBack={() => setCurrentPage("dashboard")}
             onLogout={handleLogout}

--- a/frontend/src/popup/DashboardPage.jsx
+++ b/frontend/src/popup/DashboardPage.jsx
@@ -37,7 +37,6 @@ export default function DashboardPage({
   user,
   onLogout,
   onNavigateToAssistant,
-  onNavigateToStudy,
 }) {
   const [currentTab, setCurrentTab] = useState(null);
   const [piazzaInfo, setPiazzaInfo] = useState(null);
@@ -357,7 +356,12 @@ export default function DashboardPage({
                   Assistant
                 </button>
                 <button
-                  onClick={onNavigateToStudy}
+                  onClick={() => {
+                    const url = new URL(chrome.runtime.getURL("studytab.html"));
+                    if (piazzaInfo?.classId)
+                      url.searchParams.set("course_id", piazzaInfo.classId);
+                    chrome.tabs.create({ url: url.toString() });
+                  }}
                   className="flex-1 px-3 py-2 bg-gray-100 border border-gray-200 rounded-md text-xs font-medium cursor-pointer flex items-center justify-center gap-1.5 transition-all hover:bg-gray-200 hover:border-gray-300"
                 >
                   <span>📚</span>

--- a/frontend/src/popup/DashboardPage.jsx
+++ b/frontend/src/popup/DashboardPage.jsx
@@ -37,6 +37,7 @@ export default function DashboardPage({
   user,
   onLogout,
   onNavigateToAssistant,
+  onNavigateToStudy,
 }) {
   const [currentTab, setCurrentTab] = useState(null);
   const [piazzaInfo, setPiazzaInfo] = useState(null);
@@ -137,7 +138,7 @@ export default function DashboardPage({
           isPiazza: true,
           fullUrl: tab.url,
           classId: pathParts[1] || null,
-          postId: url.searchParams.get("cid") || null,
+          postId: pathParts[2] === "post" ? pathParts[3] || null : null,
           pathname: url.pathname,
           threadName: null,
         };
@@ -354,6 +355,13 @@ export default function DashboardPage({
                 >
                   <span>📊</span>
                   Assistant
+                </button>
+                <button
+                  onClick={onNavigateToStudy}
+                  className="flex-1 px-3 py-2 bg-gray-100 border border-gray-200 rounded-md text-xs font-medium cursor-pointer flex items-center justify-center gap-1.5 transition-all hover:bg-gray-200 hover:border-gray-300"
+                >
+                  <span>📚</span>
+                  Study Materials
                 </button>
                 <button
                   onClick={handleIngestThread}

--- a/frontend/src/popup/StudyMaterialsPage.jsx
+++ b/frontend/src/popup/StudyMaterialsPage.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+
+/* global chrome */
+const API_ENDPOINT = process.env.API_ENDPOINT || "http://localhost:8000/api/v1";
+
+export default function StudyMaterialsPage({ user, onBack, onLogout }) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [results, setResults] = useState(null); // { quiz, flashcards, summary }
+
+  useEffect(() => {
+    generateAll();
+  }, []);
+
+  const generateAll = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    // Detect Piazza class ID from active tab
+    let piazza_course_id;
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tab && tab.url && tab.url.includes("piazza.com")) {
+        const url = new URL(tab.url);
+        const pathParts = url.pathname.split("/").filter(Boolean);
+        piazza_course_id = pathParts[1];
+      }
+    } catch (err) {
+      console.error("Error reading tab info:", err);
+    }
+
+    if (!piazza_course_id) {
+      setError("No Piazza course detected. Navigate to a Piazza class page first.");
+      setIsLoading(false);
+      return;
+    }
+
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${user.access_token}`,
+    };
+
+    try {
+      const [quizRes, flashcardsRes, summaryRes] = await Promise.all([
+        fetch(`${API_ENDPOINT}/study/quiz/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Quiz",
+            difficulty: "medium",
+            num_questions: 5,
+          }),
+        }),
+        fetch(`${API_ENDPOINT}/study/flashcards/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Flashcards",
+          }),
+        }),
+        fetch(`${API_ENDPOINT}/study/summary/generate`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            piazza_course_id,
+            title: "Auto Summary",
+            summary_type: "weekly",
+          }),
+        }),
+      ]);
+
+      // Handle 401 on any call
+      if (
+        quizRes.status === 401 ||
+        flashcardsRes.status === 401 ||
+        summaryRes.status === 401
+      ) {
+        onLogout();
+        return;
+      }
+
+      const [quiz, flashcards, summary] = await Promise.all([
+        quizRes.json(),
+        flashcardsRes.json(),
+        summaryRes.json(),
+      ]);
+
+      setResults({ quiz, flashcards, summary });
+    } catch (err) {
+      setError(`Failed to generate study materials: ${err.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-[500px]">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-purple-500 to-purple-700 p-5 flex items-center gap-3 text-white">
+        <button
+          onClick={onBack}
+          className="bg-white/20 border-none text-white w-8 h-8 rounded-md cursor-pointer text-base flex items-center justify-center transition-colors hover:bg-white/30"
+          title="Back"
+        >
+          ←
+        </button>
+        <div className="flex-1">
+          <h2 className="text-base font-semibold m-0">Study Materials</h2>
+          <p className="text-xs m-0 mt-0.5 opacity-90">{user.name}</p>
+        </div>
+        <button
+          onClick={onLogout}
+          className="bg-white/20 border-none text-white px-3 py-1.5 rounded-md cursor-pointer text-xs transition-colors hover:bg-white/30"
+        >
+          Logout
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center flex-1 gap-4 py-16">
+            <div className="w-10 h-10 border-3 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
+            <p className="text-gray-600 text-sm">Generating study materials…</p>
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {results && !isLoading && (
+          <>
+            <Section title="Quiz" data={results.quiz} />
+            <Section title="Flashcards" data={results.flashcards} />
+            <Section title="Summary" data={results.summary} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, data }) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
+        <h3 className="text-sm font-semibold text-gray-800 m-0">{title}</h3>
+      </div>
+      <pre className="p-4 text-xs text-gray-700 overflow-x-auto whitespace-pre-wrap break-words m-0">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/popup/StudyMaterialsPage.jsx
+++ b/frontend/src/popup/StudyMaterialsPage.jsx
@@ -1,159 +1,1437 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 /* global chrome */
 const API_ENDPOINT = process.env.API_ENDPOINT || "http://localhost:8000/api/v1";
 
-export default function StudyMaterialsPage({ user, onBack, onLogout }) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [results, setResults] = useState(null); // { quiz, flashcards, summary }
+// Used in the top bar (includes Home)
+const TOP_NAV_ITEMS = [
+  { key: "home", label: "Home" },
+  { key: "quiz", label: "Quiz" },
+  { key: "flashcards", label: "Flashcards" },
+  { key: "summary", label: "Summary" },
+];
 
-  useEffect(() => {
-    generateAll();
-  }, []);
+// Used only for the homepage cards
+const SECTION_ITEMS = [
+  { key: "quiz", label: "Quiz", icon: "📝", desc: "Test your knowledge" },
+  { key: "flashcards", label: "Flashcards", icon: "🃏", desc: "Review key terms" },
+  { key: "summary", label: "Summary", icon: "📄", desc: "Quick overview" },
+];
 
-  const generateAll = async () => {
-    setIsLoading(true);
-    setError(null);
+const lightTheme = {
+  bg: "#ffffff",
+  cardBg: "#ffffff",
+  cardBgHover: "#f5f3ff",
+  text: "#111827",
+  textMuted: "#6b7280",
+  accent: "#7c3aed",
+  pillBg: "#7c3aed",
+  pillText: "#ffffff",
+  cardBorder: "#e5e7eb",
+  cardBorderHover: "#7c3aed",
+  spinnerTrack: "#e5e7eb",
+  spinnerFill: "#a855f7",
+};
 
-    // Detect Piazza class ID from active tab
-    let piazza_course_id;
+const darkTheme = {
+  bg: "#222831",
+  cardBg: "#393E46",
+  cardBgHover: "#454c57",
+  text: "#DFD0B8",
+  textMuted: "#948979",
+  accent: "#DFD0B8",
+  pillBg: "#DFD0B8",
+  pillText: "#222831",
+  cardBorder: "#505863",
+  cardBorderHover: "#948979",
+  spinnerTrack: "#505863",
+  spinnerFill: "#DFD0B8",
+};
+
+export default function StudyMaterialsPage({ user, onLogout, piazzaCourseId }) {
+  const [view, setView] = useState("home");
+  const [darkMode, setDarkMode] = useState(false);
+  const [loadingKey, setLoadingKey] = useState(null);
+  const [results, setResults] = useState({ quiz: null, flashcards: null, summary: null });
+  const [errors, setErrors] = useState({ quiz: null, flashcards: null, summary: null });
+  const [quizRetryKey, setQuizRetryKey] = useState(0);
+
+  const theme = darkMode ? darkTheme : lightTheme;
+
+  const resolveCourseId = async () => {
+    if (piazzaCourseId) return piazzaCourseId;
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (tab && tab.url && tab.url.includes("piazza.com")) {
-        const url = new URL(tab.url);
-        const pathParts = url.pathname.split("/").filter(Boolean);
-        piazza_course_id = pathParts[1];
+      if (tab?.url?.includes("piazza.com")) {
+        const pathParts = new URL(tab.url).pathname.split("/").filter(Boolean);
+        return pathParts[1] || null;
       }
     } catch (err) {
       console.error("Error reading tab info:", err);
     }
+    return null;
+  };
 
-    if (!piazza_course_id) {
-      setError("No Piazza course detected. Navigate to a Piazza class page first.");
-      setIsLoading(false);
+  const handleNavigate = async (key, force = false) => {
+    if (key === "home") {
+      setView("home");
       return;
     }
 
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${user.access_token}`,
-    };
+    setView(key);
+
+    // Already cached — no need to re-fetch
+    if (!force && results[key] !== null) return;
+
+    setLoadingKey(key);
 
     try {
-      const [quizRes, flashcardsRes, summaryRes] = await Promise.all([
-        fetch(`${API_ENDPOINT}/study/quiz/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Quiz",
-            difficulty: "medium",
-            num_questions: 5,
-          }),
-        }),
-        fetch(`${API_ENDPOINT}/study/flashcards/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Flashcards",
-          }),
-        }),
-        fetch(`${API_ENDPOINT}/study/summary/generate`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            piazza_course_id,
-            title: "Auto Summary",
-            summary_type: "weekly",
-          }),
-        }),
-      ]);
-
-      // Handle 401 on any call
-      if (
-        quizRes.status === 401 ||
-        flashcardsRes.status === 401 ||
-        summaryRes.status === 401
-      ) {
-        onLogout();
+      const piazza_course_id = await resolveCourseId();
+      if (!piazza_course_id) {
+        setErrors(prev => ({ ...prev, [key]: "No Piazza course detected. Navigate to a Piazza class page first." }));
         return;
       }
 
-      const [quiz, flashcards, summary] = await Promise.all([
-        quizRes.json(),
-        flashcardsRes.json(),
-        summaryRes.json(),
-      ]);
+      const headers = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${user.access_token}`,
+      };
 
-      setResults({ quiz, flashcards, summary });
+      const configs = {
+        quiz: {
+          url: `${API_ENDPOINT}/study/quiz/generate`,
+          body: { piazza_course_id, title: "Auto Quiz", difficulty: "medium", num_questions: 7 },
+        },
+        flashcards: {
+          url: `${API_ENDPOINT}/study/flashcards/generate`,
+          body: { piazza_course_id, title: "Auto Flashcards" },
+        },
+        summary: {
+          url: `${API_ENDPOINT}/study/summary/generate`,
+          body: { piazza_course_id, title: "Auto Summary", summary_type: "weekly" },
+        },
+      };
+
+      const { url, body } = configs[key];
+      const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+      if (res.status === 401) { onLogout(); return; }
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = await res.json();
+      setResults(prev => ({ ...prev, [key]: data }));
     } catch (err) {
-      setError(`Failed to generate study materials: ${err.message}`);
+      setErrors(prev => ({ ...prev, [key]: err.message }));
     } finally {
-      setIsLoading(false);
+      setLoadingKey(null);
     }
   };
 
+  const showQuizView = view === "quiz" && results.quiz && loadingKey !== "quiz" && !errors.quiz;
+  const showFlashcardsView = view === "flashcards" && results.flashcards && loadingKey !== "flashcards" && !errors.flashcards;
+
   return (
-    <div className="flex flex-col min-h-[500px]">
-      {/* Header */}
-      <div className="bg-gradient-to-r from-purple-500 to-purple-700 p-5 flex items-center gap-3 text-white">
-        <button
-          onClick={onBack}
-          className="bg-white/20 border-none text-white w-8 h-8 rounded-md cursor-pointer text-base flex items-center justify-center transition-colors hover:bg-white/30"
-          title="Back"
-        >
-          ←
-        </button>
-        <div className="flex-1">
-          <h2 className="text-base font-semibold m-0">Study Materials</h2>
-          <p className="text-xs m-0 mt-0.5 opacity-90">{user.name}</p>
+    <div
+      style={{
+        backgroundColor: theme.bg,
+        color: theme.text,
+        minHeight: "100vh",
+        transition: "background-color 300ms ease, color 300ms ease",
+      }}
+      className="flex flex-col"
+    >
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-8 py-4">
+        <SlidingPillNav theme={theme} items={TOP_NAV_ITEMS} activeKey={view} onSelect={handleNavigate} />
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setDarkMode(d => !d)}
+            style={{ background: "none", border: "none", cursor: "pointer", fontSize: "20px", lineHeight: 1 }}
+            title={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {darkMode ? "☀️" : "🌙"}
+          </button>
+          <button
+            onClick={onLogout}
+            style={{
+              color: theme.textMuted,
+              backgroundColor: "transparent",
+              border: `1px solid ${theme.cardBorder}`,
+              borderRadius: "6px",
+              padding: "5px 14px",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontWeight: "500",
+            }}
+          >
+            Logout
+          </button>
         </div>
+      </div>
+
+      {view === "home" ? (
+        <HomePage theme={theme} onNavigate={handleNavigate} />
+      ) : showQuizView ? (
+        <QuizView
+          key={quizRetryKey}
+          theme={theme}
+          quizData={results.quiz}
+          user={user}
+          onRetry={() => setQuizRetryKey(k => k + 1)}
+          onNewQuiz={() => {
+            setResults(prev => ({ ...prev, quiz: null }));
+            setErrors(prev => ({ ...prev, quiz: null }));
+            handleNavigate("quiz", true);
+          }}
+        />
+      ) : showFlashcardsView ? (
+        <FlashcardsView
+          theme={theme}
+          flashcardData={results.flashcards}
+          user={user}
+          onNewDeck={() => {
+            setResults(prev => ({ ...prev, flashcards: null }));
+            setErrors(prev => ({ ...prev, flashcards: null }));
+            handleNavigate("flashcards", true);
+          }}
+        />
+      ) : (
+        <SectionView
+          theme={theme}
+          view={view}
+          isLoading={loadingKey === view}
+          result={results[view]}
+          error={errors[view]}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Quiz Components ──────────────────────────────────────────────────────────
+
+function QuizView({ theme, quizData, user, onRetry, onNewQuiz }) {
+  const { questions, id, title, difficulty } = quizData;
+
+  const [mcAnswers, setMcAnswers] = useState({});
+  const [msSelections, setMsSelections] = useState({});
+  const [msAnswers, setMsAnswers] = useState({});
+  const [lockedQuestions, setLockedQuestions] = useState(new Set());
+  const [revealCorrect, setRevealCorrect] = useState(new Set());
+  const [phase, setPhase] = useState("taking");
+  const [quizResult, setQuizResult] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const allAnswered = questions.every((_, i) => lockedQuestions.has(i));
+
+  const handleMCAnswer = (qIdx, selectedOption) => {
+    if (lockedQuestions.has(qIdx)) return;
+    const correct = questions[qIdx].correct_answer;
+    setMcAnswers(prev => ({ ...prev, [qIdx]: selectedOption }));
+    setLockedQuestions(prev => new Set([...prev, qIdx]));
+    if (selectedOption !== correct) {
+      setTimeout(() => {
+        setRevealCorrect(prev => new Set([...prev, qIdx]));
+      }, 800);
+    } else {
+      setRevealCorrect(prev => new Set([...prev, qIdx]));
+    }
+  };
+
+  const handleMSToggle = (qIdx, option) => {
+    if (lockedQuestions.has(qIdx)) return;
+    setMsSelections(prev => {
+      const current = prev[qIdx] || [];
+      if (current.includes(option)) {
+        return { ...prev, [qIdx]: current.filter(o => o !== option) };
+      }
+      return { ...prev, [qIdx]: [...current, option] };
+    });
+  };
+
+  const handleMSSubmit = (qIdx) => {
+    if (lockedQuestions.has(qIdx)) return;
+    const selected = msSelections[qIdx] || [];
+    setMsAnswers(prev => ({ ...prev, [qIdx]: selected }));
+    setLockedQuestions(prev => new Set([...prev, qIdx]));
+    setRevealCorrect(prev => new Set([...prev, qIdx]));
+  };
+
+  const handleFinishQuiz = async () => {
+    setIsSubmitting(true);
+    const answersArray = questions.map((q, i) =>
+      q.type === "multiple_select" ? (msAnswers[i] || []) : (mcAnswers[i] || "")
+    );
+    try {
+      const res = await fetch(`${API_ENDPOINT}/study/quiz/${id}/submit`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${user.access_token}`,
+        },
+        body: JSON.stringify({ answers: answersArray }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setQuizResult(data);
+      }
+    } catch (err) {
+      console.error("Quiz submit failed:", err);
+    } finally {
+      setIsSubmitting(false);
+      setPhase("results");
+    }
+  };
+
+  if (phase === "results") {
+    return (
+      <QuizResults
+        theme={theme}
+        result={quizResult}
+        totalCount={questions.length}
+        onRetry={onRetry}
+        onNewQuiz={onNewQuiz}
+      />
+    );
+  }
+
+  const difficultyColors = {
+    easy: { bg: "#dcfce7", text: "#15803d", border: "#86efac" },
+    medium: { bg: "#fef9c3", text: "#a16207", border: "#fde047" },
+    hard: { bg: "#fee2e2", text: "#b91c1c", border: "#fca5a5" },
+  };
+  const diffColor = difficultyColors[difficulty] || difficultyColors.medium;
+  const accentText = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  return (
+    <div className="flex flex-col flex-1" style={{ paddingBottom: "80px" }}>
+      {/* Quiz header */}
+      <div style={{ padding: "0 32px 20px", maxWidth: "760px", width: "100%", margin: "0 auto" }}>
+        <div className="flex items-center gap-3" style={{ marginBottom: "4px" }}>
+          <h2 style={{ margin: 0, fontSize: "20px", fontWeight: "700", color: theme.text }}>
+            {title}
+          </h2>
+          <span
+            style={{
+              backgroundColor: diffColor.bg,
+              color: diffColor.text,
+              border: `1px solid ${diffColor.border}`,
+              borderRadius: "9999px",
+              padding: "2px 10px",
+              fontSize: "11px",
+              fontWeight: "600",
+              textTransform: "capitalize",
+            }}
+          >
+            {difficulty}
+          </span>
+        </div>
+        <p style={{ margin: 0, fontSize: "13px", color: theme.textMuted }}>
+          {questions.length} questions — answer all to finish
+        </p>
+      </div>
+
+      {/* Questions list */}
+      <div
+        style={{
+          maxWidth: "760px",
+          width: "100%",
+          margin: "0 auto",
+          padding: "0 32px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "20px",
+        }}
+      >
+        {questions.map((q, qIdx) => {
+          const isLocked = lockedQuestions.has(qIdx);
+          const isRevealed = revealCorrect.has(qIdx);
+          const isMS = q.type === "multiple_select";
+          const msSelected = msSelections[qIdx] || [];
+          const msLocked = msAnswers[qIdx] || [];
+          const correctAnswers = Array.isArray(q.correct_answer)
+            ? q.correct_answer
+            : [q.correct_answer];
+
+          return (
+            <div
+              key={qIdx}
+              style={{
+                backgroundColor: theme.cardBg,
+                border: `1px solid ${isLocked && isRevealed ? theme.cardBorder : theme.cardBorder}`,
+                borderRadius: "12px",
+                padding: "20px",
+                transition: "border-color 200ms ease",
+              }}
+            >
+              {/* Question number + text */}
+              <div className="flex items-start gap-3" style={{ marginBottom: "14px" }}>
+                <span
+                  style={{
+                    minWidth: "26px",
+                    height: "26px",
+                    borderRadius: "50%",
+                    backgroundColor: isLocked
+                      ? (isRevealed ? "#dcfce7" : "#fee2e2")
+                      : theme.accent,
+                    color: isLocked
+                      ? (isRevealed ? "#15803d" : "#b91c1c")
+                      : accentText,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "12px",
+                    fontWeight: "700",
+                    flexShrink: 0,
+                    transition: "background-color 400ms ease, color 400ms ease",
+                  }}
+                >
+                  {qIdx + 1}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <p style={{ margin: 0, fontSize: "14px", fontWeight: "600", color: theme.text, lineHeight: "1.55" }}>
+                    {q.question}
+                  </p>
+                  {isMS && (
+                    <span style={{ fontSize: "11px", color: theme.textMuted, marginTop: "4px", display: "block" }}>
+                      Select all that apply
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Options */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "8px", paddingLeft: "38px" }}>
+                {q.options.map((option, oIdx) => {
+                  if (isMS) {
+                    const isChecked = isLocked ? msLocked.includes(option) : msSelected.includes(option);
+                    const isCorrectOpt = correctAnswers.includes(option);
+
+                    let optBg = theme.cardBg;
+                    let optBorder = theme.cardBorder;
+                    let optColor = theme.text;
+                    let optOpacity = 1;
+
+                    if (isLocked) {
+                      if (isChecked && isCorrectOpt) {
+                        optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                      } else if (isChecked && !isCorrectOpt) {
+                        optBg = "#fee2e2"; optBorder = "#dc2626"; optColor = "#b91c1c";
+                      } else if (!isChecked && isCorrectOpt) {
+                        optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                      } else {
+                        optOpacity = 0.5;
+                      }
+                    }
+
+                    const checkBorderColor = isLocked
+                      ? optBorder
+                      : (isChecked ? theme.accent : theme.cardBorder);
+                    const checkBg = isChecked ? (isLocked ? optBorder : theme.accent) : "transparent";
+
+                    return (
+                      <button
+                        key={oIdx}
+                        onClick={() => handleMSToggle(qIdx, option)}
+                        disabled={isLocked}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "10px",
+                          width: "100%",
+                          padding: "10px 14px",
+                          borderRadius: "8px",
+                          border: `1.5px solid ${optBorder}`,
+                          backgroundColor: optBg,
+                          color: optColor,
+                          cursor: isLocked ? "default" : "pointer",
+                          textAlign: "left",
+                          fontFamily: "inherit",
+                          opacity: optOpacity,
+                          transition: "all 200ms ease",
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: "16px",
+                            height: "16px",
+                            borderRadius: "4px",
+                            border: `2px solid ${checkBorderColor}`,
+                            backgroundColor: checkBg,
+                            flexShrink: 0,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            transition: "all 150ms ease",
+                          }}
+                        >
+                          {isChecked && (
+                            <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                              <path
+                                d="M1 4L3.5 6.5L9 1"
+                                stroke="#fff"
+                                strokeWidth="1.8"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          )}
+                        </span>
+                        <span style={{ fontSize: "13px", fontWeight: "500" }}>{option}</span>
+                      </button>
+                    );
+                  }
+
+                  // Multiple choice
+                  const userAnswer = mcAnswers[qIdx];
+                  const isSelected = option === userAnswer;
+                  const isCorrectOpt = option === q.correct_answer;
+
+                  let optBg = theme.cardBg;
+                  let optBorder = theme.cardBorder;
+                  let optColor = theme.text;
+                  let optOpacity = 1;
+
+                  if (isLocked) {
+                    if (isSelected && isCorrectOpt) {
+                      optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                    } else if (isSelected && !isCorrectOpt) {
+                      optBg = "#fee2e2"; optBorder = "#dc2626"; optColor = "#b91c1c";
+                    } else if (!isSelected && isCorrectOpt && isRevealed) {
+                      optBg = "#dcfce7"; optBorder = "#16a34a"; optColor = "#15803d";
+                    } else {
+                      optOpacity = 0.5;
+                    }
+                  }
+
+                  return (
+                    <button
+                      key={oIdx}
+                      onClick={() => handleMCAnswer(qIdx, option)}
+                      disabled={isLocked}
+                      style={{
+                        width: "100%",
+                        padding: "10px 14px",
+                        borderRadius: "8px",
+                        border: `1.5px solid ${optBorder}`,
+                        backgroundColor: optBg,
+                        color: optColor,
+                        cursor: isLocked ? "default" : "pointer",
+                        textAlign: "left",
+                        fontFamily: "inherit",
+                        opacity: optOpacity,
+                        transition: "all 200ms ease",
+                      }}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: "500" }}>{option}</span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* MS per-question submit button */}
+              {isMS && !isLocked && (
+                <div style={{ paddingLeft: "38px", marginTop: "12px" }}>
+                  <button
+                    onClick={() => handleMSSubmit(qIdx)}
+                    disabled={msSelected.length === 0}
+                    style={{
+                      backgroundColor: msSelected.length === 0 ? theme.cardBorder : theme.accent,
+                      color: msSelected.length === 0 ? theme.textMuted : accentText,
+                      border: "none",
+                      borderRadius: "8px",
+                      padding: "8px 18px",
+                      fontSize: "12px",
+                      fontWeight: "600",
+                      cursor: msSelected.length === 0 ? "not-allowed" : "pointer",
+                      transition: "all 150ms ease",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    Submit Answer
+                  </button>
+                </div>
+              )}
+
+              {/* Explanation shown after answering */}
+              {isLocked && isRevealed && q.explanation && (
+                <div style={{ paddingLeft: "38px", marginTop: "12px" }}>
+                  <div
+                    style={{
+                      backgroundColor: theme.cardBgHover,
+                      borderRadius: "8px",
+                      padding: "10px 14px",
+                      fontSize: "12px",
+                      color: theme.textMuted,
+                      lineHeight: "1.6",
+                    }}
+                  >
+                    <span style={{ fontWeight: "600", color: theme.accent }}>Explanation: </span>
+                    {q.explanation}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Sticky bottom bar with Finish Quiz button */}
+      <div
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          backgroundColor: theme.bg,
+          borderTop: `1px solid ${theme.cardBorder}`,
+          padding: "12px 32px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          zIndex: 10,
+        }}
+      >
+        <span style={{ fontSize: "13px", color: theme.textMuted }}>
+          {lockedQuestions.size} / {questions.length} answered
+        </span>
         <button
-          onClick={onLogout}
-          className="bg-white/20 border-none text-white px-3 py-1.5 rounded-md cursor-pointer text-xs transition-colors hover:bg-white/30"
+          onClick={handleFinishQuiz}
+          disabled={!allAnswered || isSubmitting}
+          style={{
+            backgroundColor: allAnswered ? theme.accent : theme.cardBorder,
+            color: allAnswered ? accentText : theme.textMuted,
+            border: "none",
+            borderRadius: "8px",
+            padding: "10px 24px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: allAnswered && !isSubmitting ? "pointer" : "not-allowed",
+            transition: "all 150ms ease",
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            fontFamily: "inherit",
+          }}
         >
-          Logout
+          {isSubmitting ? (
+            <>
+              <span
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  borderRadius: "50%",
+                  border: "2px solid rgba(255,255,255,0.35)",
+                  borderTopColor: "#fff",
+                  display: "inline-block",
+                  animation: "spin 0.6s linear infinite",
+                }}
+              />
+              Submitting…
+            </>
+          ) : (
+            "Finish Quiz"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function QuizResults({ theme, result, totalCount, onRetry, onNewQuiz }) {
+  const score = result ? result.score : null;
+  const correctCount = result ? result.correct_count : 0;
+  const total = result ? result.total_count : totalCount;
+  const accentText = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  let emoji, message;
+  if (score === null) {
+    emoji = "📊"; message = "Quiz complete!";
+  } else if (score >= 80) {
+    emoji = "🎉"; message = "Great job!";
+  } else if (score >= 60) {
+    emoji = "👍"; message = "Good effort!";
+  } else {
+    emoji = "📖"; message = "Keep practicing!";
+  }
+
+  const scoreColor = score === null ? theme.accent
+    : score >= 80 ? "#16a34a"
+    : score >= 60 ? "#d97706"
+    : "#dc2626";
+
+  return (
+    <div
+      className="flex flex-col flex-1 items-center justify-center"
+      style={{ padding: "40px 32px" }}
+    >
+      <div
+        style={{
+          backgroundColor: theme.cardBg,
+          border: `1px solid ${theme.cardBorder}`,
+          borderRadius: "20px",
+          padding: "48px 56px",
+          maxWidth: "420px",
+          width: "100%",
+          textAlign: "center",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "12px" }}>{emoji}</div>
+        <h2 style={{ margin: "0 0 8px", fontSize: "22px", fontWeight: "800", color: theme.text }}>
+          {message}
+        </h2>
+
+        {score !== null ? (
+          <>
+            <div
+              style={{
+                fontSize: "60px",
+                fontWeight: "800",
+                color: scoreColor,
+                lineHeight: 1,
+                margin: "20px 0 8px",
+              }}
+            >
+              {score}%
+            </div>
+            <p style={{ margin: "0 0 24px", fontSize: "15px", color: theme.textMuted }}>
+              {correctCount} / {total} correct
+            </p>
+            {/* Progress bar */}
+            <div
+              style={{
+                height: "8px",
+                borderRadius: "9999px",
+                backgroundColor: theme.cardBorder,
+                overflow: "hidden",
+                marginBottom: "32px",
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${score}%`,
+                  borderRadius: "9999px",
+                  backgroundColor: scoreColor,
+                  transition: "width 600ms ease",
+                }}
+              />
+            </div>
+          </>
+        ) : (
+          <p style={{ margin: "0 0 32px", fontSize: "14px", color: theme.textMuted }}>
+            {correctCount} / {total} answered
+          </p>
+        )}
+
+        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
+          <button
+            onClick={onRetry}
+            style={{
+              backgroundColor: "transparent",
+              color: theme.text,
+              border: `1.5px solid ${theme.cardBorder}`,
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            Try Again
+          </button>
+          <button
+            onClick={onNewQuiz}
+            style={{
+              backgroundColor: theme.accent,
+              color: accentText,
+              border: "none",
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            New Quiz
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Flashcard Components ─────────────────────────────────────────────────────
+
+const CARD_TYPE_STYLES = {
+  concept:    { bg: "#ede9fe", text: "#7c3aed", border: "#c4b5fd", label: "Concept"    },
+  definition: { bg: "#dcfce7", text: "#16a34a", border: "#86efac", label: "Definition" },
+  qa:         { bg: "#fff7ed", text: "#c2410c", border: "#fdba74", label: "Q & A"      },
+};
+
+function FlashcardsView({ theme, flashcardData, user, onNewDeck }) {
+  const { cards, title } = flashcardData;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isFlipped, setIsFlipped]       = useState(false);
+  const [ratings, setRatings]           = useState({});
+  const [isRating, setIsRating]         = useState(false);
+  const [sessionPhase, setSessionPhase] = useState("active");
+
+  const card       = cards[currentIndex];
+  const totalCards = cards.length;
+  const typeStyle  = CARD_TYPE_STYLES[card.card_type] || CARD_TYPE_STYLES.concept;
+  const isRated    = ratings[card.id] !== undefined;
+
+  const handlePrev = () => {
+    if (currentIndex === 0) return;
+    setIsFlipped(false);
+    setCurrentIndex(i => i - 1);
+  };
+
+  const handleNext = () => {
+    if (currentIndex === totalCards - 1) return;
+    setIsFlipped(false);
+    setCurrentIndex(i => i + 1);
+  };
+
+  const handleRate = async (quality) => {
+    if (isRating) return;
+    setIsRating(true);
+    setRatings(prev => ({ ...prev, [card.id]: quality }));
+
+    try {
+      await fetch(`${API_ENDPOINT}/study/flashcards/${card.id}/progress`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${user.access_token}`,
+        },
+        body: JSON.stringify({ quality }),
+      });
+    } catch (err) {
+      console.error("Progress update failed:", err);
+    } finally {
+      setIsRating(false);
+    }
+
+    if (currentIndex < totalCards - 1) {
+      setIsFlipped(false);
+      setCurrentIndex(i => i + 1);
+    } else {
+      setSessionPhase("complete");
+    }
+  };
+
+  if (sessionPhase === "complete") {
+    return (
+      <FlashcardSessionComplete
+        theme={theme}
+        cards={cards}
+        ratings={ratings}
+        onReviewAgain={() => {
+          setCurrentIndex(0);
+          setIsFlipped(false);
+          setRatings({});
+          setSessionPhase("active");
+        }}
+        onNewDeck={onNewDeck}
+      />
+    );
+  }
+
+  const cardSceneStyle = {
+    perspective: "1200px",
+    width: "100%",
+    maxWidth: "560px",
+    height: "320px",
+    cursor: "pointer",
+    userSelect: "none",
+  };
+
+  const cardInnerStyle = {
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    transformStyle: "preserve-3d",
+    transition: "transform 480ms cubic-bezier(0.4, 0, 0.2, 1)",
+    transform: isFlipped ? "rotateY(180deg)" : "rotateY(0deg)",
+  };
+
+  const faceBaseStyle = {
+    position: "absolute",
+    inset: 0,
+    backfaceVisibility: "hidden",
+    WebkitBackfaceVisibility: "hidden",
+    borderRadius: "16px",
+    border: `1px solid ${theme.cardBorder}`,
+    backgroundColor: theme.cardBg,
+    boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+    display: "flex",
+    flexDirection: "column",
+    padding: "24px",
+    overflow: "hidden",
+  };
+
+  const backFaceStyle = {
+    ...faceBaseStyle,
+    transform: "rotateY(180deg)",
+    border: `1px solid ${theme.cardBorderHover}`,
+    backgroundColor: theme.cardBgHover,
+  };
+
+  const arrowBtn = (disabled) => ({
+    width: "40px",
+    height: "40px",
+    borderRadius: "50%",
+    border: `1.5px solid ${disabled ? theme.cardBorder : theme.accent}`,
+    backgroundColor: "transparent",
+    color: disabled ? theme.cardBorder : theme.accent,
+    cursor: disabled ? "default" : "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    fontSize: "22px",
+    lineHeight: 1,
+    transition: "all 150ms ease",
+    fontFamily: "inherit",
+  });
+
+  return (
+    <div className="flex flex-col flex-1" style={{ paddingBottom: "80px" }}>
+      {/* Header */}
+      <div style={{ padding: "0 32px 20px", maxWidth: "760px", width: "100%", margin: "0 auto" }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: "10px" }}>
+          <h2 style={{ margin: 0, fontSize: "20px", fontWeight: "700", color: theme.text }}>
+            {title}
+          </h2>
+          <span style={{ fontSize: "13px", color: theme.textMuted, fontWeight: "600" }}>
+            {currentIndex + 1} / {totalCards}
+          </span>
+        </div>
+        <div style={{ height: "6px", borderRadius: "9999px", backgroundColor: theme.cardBorder, overflow: "hidden" }}>
+          <div
+            style={{
+              height: "100%",
+              width: `${((currentIndex + 1) / totalCards) * 100}%`,
+              borderRadius: "9999px",
+              backgroundColor: theme.accent,
+              transition: "width 400ms ease",
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Card + Arrows */}
+      <div
+        className="flex flex-1 items-center justify-center"
+        style={{ padding: "0 24px", gap: "16px" }}
+      >
+        {/* Left arrow */}
+        <button onClick={handlePrev} disabled={currentIndex === 0} style={arrowBtn(currentIndex === 0)}>
+          ‹
+        </button>
+
+        {/* 3D flip card */}
+        <div style={cardSceneStyle} onClick={() => setIsFlipped(f => !f)}>
+          <div style={cardInnerStyle}>
+
+            {/* Front face */}
+            <div style={faceBaseStyle}>
+              <div className="flex items-center justify-between" style={{ marginBottom: "16px" }}>
+                <span
+                  style={{
+                    backgroundColor: typeStyle.bg,
+                    color: typeStyle.text,
+                    border: `1px solid ${typeStyle.border}`,
+                    borderRadius: "9999px",
+                    padding: "3px 10px",
+                    fontSize: "11px",
+                    fontWeight: "600",
+                  }}
+                >
+                  {typeStyle.label}
+                </span>
+                {isRated && (
+                  <span
+                    style={{
+                      width: "8px",
+                      height: "8px",
+                      borderRadius: "50%",
+                      backgroundColor: ratings[card.id] >= 4 ? "#16a34a" : "#dc2626",
+                      display: "inline-block",
+                    }}
+                  />
+                )}
+              </div>
+              <div className="flex flex-1 items-center justify-center">
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "16px",
+                    fontWeight: "600",
+                    color: theme.text,
+                    lineHeight: "1.6",
+                    textAlign: "center",
+                  }}
+                >
+                  {card.front}
+                </p>
+              </div>
+              <p style={{ margin: 0, fontSize: "12px", color: theme.textMuted, textAlign: "center" }}>
+                Click to reveal answer
+              </p>
+            </div>
+
+            {/* Back face */}
+            <div style={backFaceStyle}>
+              <div style={{ marginBottom: "16px" }}>
+                <span
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: "700",
+                    color: theme.accent,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                  }}
+                >
+                  Answer
+                </span>
+              </div>
+              <div className="flex flex-1 items-center justify-center" style={{ overflowY: "auto" }}>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "14px",
+                    fontWeight: "500",
+                    color: theme.text,
+                    lineHeight: "1.7",
+                    textAlign: "center",
+                  }}
+                >
+                  {card.back}
+                </p>
+              </div>
+              <p style={{ margin: 0, fontSize: "12px", color: theme.textMuted, textAlign: "center" }}>
+                How well did you know this?
+              </p>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Right arrow */}
+        <button onClick={handleNext} disabled={currentIndex === totalCards - 1} style={arrowBtn(currentIndex === totalCards - 1)}>
+          ›
         </button>
       </div>
 
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
-        {isLoading && (
-          <div className="flex flex-col items-center justify-center flex-1 gap-4 py-16">
-            <div className="w-10 h-10 border-3 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
-            <p className="text-gray-600 text-sm">Generating study materials…</p>
-          </div>
-        )}
+      {/* Fixed bottom rating bar */}
+      <div
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          backgroundColor: theme.bg,
+          borderTop: `1px solid ${theme.cardBorder}`,
+          padding: "12px 32px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "12px",
+          zIndex: 10,
+        }}
+      >
+        <button
+          onClick={() => handleRate(1)}
+          disabled={isRating}
+          style={{
+            backgroundColor: "#fee2e2",
+            color: "#b91c1c",
+            border: "1.5px solid #fca5a5",
+            borderRadius: "8px",
+            padding: "10px 28px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: isRating ? "not-allowed" : "pointer",
+            opacity: isRating ? 0.6 : 1,
+            transition: "all 150ms ease",
+            fontFamily: "inherit",
+          }}
+        >
+          Needs Work
+        </button>
+        <button
+          onClick={() => handleRate(4)}
+          disabled={isRating}
+          style={{
+            backgroundColor: "#dcfce7",
+            color: "#15803d",
+            border: "1.5px solid #86efac",
+            borderRadius: "8px",
+            padding: "10px 28px",
+            fontSize: "13px",
+            fontWeight: "600",
+            cursor: isRating ? "not-allowed" : "pointer",
+            opacity: isRating ? 0.6 : 1,
+            transition: "all 150ms ease",
+            fontFamily: "inherit",
+          }}
+        >
+          Already Solid
+        </button>
+      </div>
+    </div>
+  );
+}
 
-        {error && !isLoading && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+function FlashcardSessionComplete({ theme, cards, ratings, onReviewAgain, onNewDeck }) {
+  const solidCount     = Object.values(ratings).filter(q => q >= 4).length;
+  const needsWorkCount = Object.values(ratings).filter(q => q < 4).length;
+  const total          = cards.length;
+  const ratedCount     = Object.keys(ratings).length;
+  const accentText     = theme === lightTheme ? "#fff" : darkTheme.pillText;
+
+  const solidRatio = ratedCount > 0 ? solidCount / ratedCount : 0;
+  let emoji, message;
+  if (solidRatio >= 0.8)      { emoji = "🎉"; message = "Excellent recall!";  }
+  else if (solidRatio >= 0.5) { emoji = "👍"; message = "Good progress!";     }
+  else                        { emoji = "📖"; message = "Keep reviewing!";     }
+
+  return (
+    <div
+      className="flex flex-col flex-1 items-center justify-center"
+      style={{ padding: "40px 32px" }}
+    >
+      <div
+        style={{
+          backgroundColor: theme.cardBg,
+          border: `1px solid ${theme.cardBorder}`,
+          borderRadius: "20px",
+          padding: "48px 56px",
+          maxWidth: "420px",
+          width: "100%",
+          textAlign: "center",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "12px" }}>{emoji}</div>
+        <h2 style={{ margin: "0 0 8px", fontSize: "22px", fontWeight: "800", color: theme.text }}>
+          {message}
+        </h2>
+        <p style={{ margin: "0 0 28px", fontSize: "14px", color: theme.textMuted }}>
+          Session complete — {total} cards reviewed
+        </p>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "12px",
+            marginBottom: "32px",
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: "#dcfce7",
+              border: "1px solid #86efac",
+              borderRadius: "12px",
+              padding: "16px 12px",
+            }}
+          >
+            <div style={{ fontSize: "28px", fontWeight: "800", color: "#15803d" }}>{solidCount}</div>
+            <div style={{ fontSize: "12px", fontWeight: "600", color: "#16a34a" }}>Already Solid</div>
+          </div>
+          <div
+            style={{
+              backgroundColor: "#fee2e2",
+              border: "1px solid #fca5a5",
+              borderRadius: "12px",
+              padding: "16px 12px",
+            }}
+          >
+            <div style={{ fontSize: "28px", fontWeight: "800", color: "#b91c1c" }}>{needsWorkCount}</div>
+            <div style={{ fontSize: "12px", fontWeight: "600", color: "#dc2626" }}>Needs Work</div>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
+          <button
+            onClick={onReviewAgain}
+            style={{
+              backgroundColor: "transparent",
+              color: theme.text,
+              border: `1.5px solid ${theme.cardBorder}`,
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            Review Again
+          </button>
+          <button
+            onClick={onNewDeck}
+            style={{
+              backgroundColor: theme.accent,
+              color: accentText,
+              border: "none",
+              borderRadius: "8px",
+              padding: "10px 22px",
+              fontSize: "13px",
+              fontWeight: "600",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 150ms ease",
+            }}
+          >
+            New Deck
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Shared Components ────────────────────────────────────────────────────────
+
+function SlidingPillNav({ theme, items, activeKey, onSelect }) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const activeIndex = items.findIndex(item => item.key === activeKey);
+  const pillIndex = hoveredIndex !== null ? hoveredIndex : activeIndex;
+  const pct = 100 / items.length;
+
+  return (
+    <div style={{ position: "relative" }} onMouseLeave={() => setHoveredIndex(null)}>
+      {/* Sliding pill */}
+      <div
+        style={{
+          position: "absolute",
+          top: "4px",
+          bottom: "4px",
+          left: `calc(${pillIndex} * ${pct}% + 4px)`,
+          width: `calc(${pct}% - 8px)`,
+          backgroundColor: theme.pillBg,
+          borderRadius: "9999px",
+          transition: "left 200ms ease, opacity 150ms ease",
+          opacity: pillIndex >= 0 ? 1 : 0,
+          zIndex: 0,
+        }}
+      />
+      {/* Nav buttons */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${items.length}, 1fr)`,
+          padding: "4px",
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {items.map((item, i) => {
+          const isHighlighted = pillIndex === i;
+          return (
+            <button
+              key={item.key}
+              onMouseEnter={() => setHoveredIndex(i)}
+              onClick={() => onSelect(item.key)}
+              style={{
+                background: "none",
+                border: "none",
+                padding: "9px 20px",
+                fontSize: "13px",
+                fontWeight: "600",
+                cursor: "pointer",
+                color: isHighlighted ? theme.pillText : theme.textMuted,
+                borderRadius: "9999px",
+                transition: "color 150ms ease",
+                textAlign: "center",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function HomePage({ theme, onNavigate }) {
+  const [hoveredCard, setHoveredCard] = useState(null);
+
+  return (
+    <div className="flex flex-col items-center flex-1 px-6" style={{ paddingBottom: "48px" }}>
+      {/* Hero */}
+      <section
+        className="flex flex-col items-center text-center"
+        style={{ paddingTop: "64px", paddingBottom: "48px", maxWidth: "560px" }}
+      >
+        <div style={{ fontSize: "52px", marginBottom: "20px" }}>📚</div>
+        <h1
+          style={{
+            color: theme.accent,
+            fontSize: "clamp(2rem, 5vw, 3rem)",
+            fontWeight: "800",
+            margin: "0 0 16px 0",
+            lineHeight: "1.15",
+          }}
+        >
+          Study Materials
+        </h1>
+        <p
+          style={{
+            color: theme.textMuted,
+            fontSize: "1rem",
+            margin: 0,
+            lineHeight: "1.7",
+          }}
+        >
+          practice and understand concepts from piazza course — learn faster!
+        </p>
+      </section>
+
+      {/* Navigation cards */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: "16px",
+          width: "100%",
+          maxWidth: "640px",
+          marginTop: "8px",
+        }}
+      >
+        {SECTION_ITEMS.map((item, i) => (
+          <button
+            key={item.key}
+            onClick={() => onNavigate(item.key)}
+            onMouseEnter={() => setHoveredCard(i)}
+            onMouseLeave={() => setHoveredCard(null)}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              textAlign: "center",
+              padding: "28px 16px",
+              backgroundColor: hoveredCard === i ? theme.cardBgHover : theme.cardBg,
+              border: `1.5px solid ${hoveredCard === i ? theme.cardBorderHover : theme.cardBorder}`,
+              borderRadius: "14px",
+              cursor: "pointer",
+              transition: "all 180ms ease",
+              transform: hoveredCard === i ? "translateY(-3px)" : "translateY(0)",
+              boxShadow:
+                hoveredCard === i
+                  ? "0 10px 30px rgba(0,0,0,0.12)"
+                  : "0 2px 8px rgba(0,0,0,0.05)",
+              color: theme.text,
+            }}
+          >
+            <span style={{ fontSize: "30px", marginBottom: "12px" }}>{item.icon}</span>
+            <span style={{ fontSize: "13px", fontWeight: "700", marginBottom: "6px" }}>
+              {item.label}
+            </span>
+            <span style={{ fontSize: "11px", color: theme.textMuted, lineHeight: "1.5" }}>
+              {item.desc}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SectionView({ theme, view, isLoading, result, error }) {
+  return (
+    <div className="flex flex-col flex-1 px-6" style={{ paddingBottom: "48px" }}>
+      {/* Content area */}
+      <div
+        className="flex-1 flex flex-col items-center justify-center"
+        style={{ maxWidth: "720px", width: "100%", margin: "0 auto" }}
+      >
+        {isLoading && <Spinner theme={theme} />}
+
+        {!isLoading && error && (
+          <div
+            style={{
+              background: "#fee2e2",
+              border: "1px solid #fecaca",
+              borderRadius: "10px",
+              padding: "16px 20px",
+              color: "#b91c1c",
+              fontSize: "14px",
+              width: "100%",
+            }}
+          >
             {error}
           </div>
         )}
 
-        {results && !isLoading && (
-          <>
-            <Section title="Quiz" data={results.quiz} />
-            <Section title="Flashcards" data={results.flashcards} />
-            <Section title="Summary" data={results.summary} />
-          </>
+        {!isLoading && result && (
+          <div
+            style={{
+              backgroundColor: theme.cardBg,
+              borderRadius: "14px",
+              border: `1px solid ${theme.cardBorder}`,
+              overflow: "hidden",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                padding: "14px 20px",
+                borderBottom: `1px solid ${theme.cardBorder}`,
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "700", color: theme.text }}>
+                {SECTION_ITEMS.find(n => n.key === view)?.label}
+              </h3>
+            </div>
+            <pre
+              style={{
+                padding: "16px 20px",
+                fontSize: "12px",
+                color: theme.textMuted,
+                overflowX: "auto",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                margin: 0,
+              }}
+            >
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </div>
         )}
       </div>
     </div>
   );
 }
 
-function Section({ title, data }) {
+function Spinner({ theme }) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
-        <h3 className="text-sm font-semibold text-gray-800 m-0">{title}</h3>
-      </div>
-      <pre className="p-4 text-xs text-gray-700 overflow-x-auto whitespace-pre-wrap break-words m-0">
-        {JSON.stringify(data, null, 2)}
-      </pre>
+    <div className="flex flex-col items-center gap-4">
+      <div
+        className="animate-spin"
+        style={{
+          width: "52px",
+          height: "52px",
+          borderRadius: "50%",
+          border: `5px solid ${theme.spinnerTrack}`,
+          borderTopColor: theme.spinnerFill,
+        }}
+      />
+      <p style={{ color: theme.textMuted, fontSize: "14px", margin: 0 }}>
+        Generating content…
+      </p>
     </div>
   );
 }

--- a/frontend/src/studytab/index.html
+++ b/frontend/src/studytab/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Study Materials – ThreadSense AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/studytab/main.jsx
+++ b/frontend/src/studytab/main.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "../popup/popup.css";
+import StudyMaterialsPage from "../popup/StudyMaterialsPage";
+
+/* global chrome */
+
+const courseId = new URLSearchParams(window.location.search).get("course_id");
+
+function StudyTab() {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    chrome.storage.local.get(["user", "authToken", "tokenExpiry"], (result) => {
+      if (result.user && result.authToken) {
+        if (result.tokenExpiry && Date.now() > result.tokenExpiry) {
+          setUser(null);
+        } else {
+          setUser({ ...result.user, access_token: result.authToken });
+        }
+      }
+      setIsLoading(false);
+    });
+  }, []);
+
+  const handleLogout = () => {
+    chrome.storage.local.remove(
+      ["user", "authToken", "refreshToken", "tokenExpiry"],
+      () => window.close()
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-10 h-10 border-4 border-gray-200 border-t-purple-500 rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-screen text-gray-600">
+        Not authenticated. Please log in via the extension popup.
+      </div>
+    );
+  }
+
+  return (
+    <StudyMaterialsPage
+      user={user}
+      piazzaCourseId={courseId}
+      onLogout={handleLogout}
+    />
+  );
+}
+
+const root = createRoot(document.getElementById("root"));
+root.render(<StudyTab />);

--- a/frontend/webpack.config.cjs
+++ b/frontend/webpack.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
     content: "./src/content/content.js",
     background: "./src/background/background.js",
     popup: "./src/popup/main.jsx",
+    studytab: "./src/studytab/main.jsx",
   },
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -79,6 +80,11 @@ module.exports = {
       template: "./src/popup/index.html",
       filename: "popup.html",
       chunks: ["popup"],
+    }),
+    new HtmlWebpackPlugin({
+      template: "./src/studytab/index.html",
+      filename: "studytab.html",
+      chunks: ["studytab"],
     }),
     new CopyPlugin({
       patterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,345 @@
+{
+  "name": "Piazza-AI-Plugin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "supabase": "^2.76.12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supabase": {
+      "version": "2.76.12",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.76.12.tgz",
+      "integrity": "sha512-UAWUjwmSOnxWNN07UOwL9Wb12HOx5jMrQ0HTSi+dKPqRc5g9kJCkp2q3i5gVNLq7NWNzpCZRixRXIQJznOGqGw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.9"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
+      "integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "supabase": "^2.76.12"
+  }
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["backend"],
+  "venvPath": "backend",
+  "venv": ".venv",
+  "pythonVersion": "3.11",
+  "pythonPlatform": "Windows",
+  "executionEnvironments": [
+    {
+      "root": "backend",
+      "pythonVersion": "3.11",
+      "extraPaths": ["backend"]
+    }
+  ]
+}

--- a/supabase/migrations/20260221000130_create_study_material.sql
+++ b/supabase/migrations/20260221000130_create_study_material.sql
@@ -34,7 +34,7 @@ CREATE TABLE flashcards (
     deck_id UUID REFERENCES flashcard_decks(id) ON DELETE CASCADE,
     front TEXT NOT NULL,
     back TEXT NOT NULL,
-    card_type TEXT DEFAULT 'basic', -- basic, cloze
+    card_type TEXT DEFAULT 'concept', -- concept, definition, qa
     -- Spaced repetition fields (SM-2 algorithm)
     ease_factor DECIMAL(3,2) DEFAULT 2.5,
     interval_days INT DEFAULT 0,

--- a/supabase/migrations/20260221000130_create_study_material.sql
+++ b/supabase/migrations/20260221000130_create_study_material.sql
@@ -1,0 +1,55 @@
+-- Quizzes
+CREATE TABLE quizzes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    piazza_course_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    difficulty TEXT CHECK (difficulty IN ('easy', 'medium', 'hard')),
+    questions JSONB NOT NULL, -- [{question, type, options[], correct_answer, explanation}]
+    source_posts TEXT[],
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE quiz_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    quiz_id UUID REFERENCES quizzes(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    answers JSONB NOT NULL,
+    score DECIMAL(5,2),
+    completed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Flashcards
+CREATE TABLE flashcard_decks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    piazza_course_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    tags TEXT[],
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE flashcards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deck_id UUID REFERENCES flashcard_decks(id) ON DELETE CASCADE,
+    front TEXT NOT NULL,
+    back TEXT NOT NULL,
+    card_type TEXT DEFAULT 'basic', -- basic, cloze
+    -- Spaced repetition fields (SM-2 algorithm)
+    ease_factor DECIMAL(3,2) DEFAULT 2.5,
+    interval_days INT DEFAULT 0,
+    next_review TIMESTAMPTZ DEFAULT NOW(),
+    review_count INT DEFAULT 0
+);
+
+-- Summaries
+CREATE TABLE summaries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    piazza_course_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    summary_type TEXT, -- thread, weekly, exam_guide
+    source_posts TEXT[],
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
# Cool lil demo video (the errors are due to my grok rate limiting me cuz i already made too many reqs 💀)
https://github.com/user-attachments/assets/96fded85-337b-45c1-ac63-12ecf8d69a32

## Summary

- **Database**: Added Supabase migration with 5 new tables (`quizzes`, `quiz_attempts`,
  `flashcard_decks`, `flashcards`, `summaries`). Quizzes store questions as JSONB,
  flashcards include SM-2 spaced repetition fields (`ease_factor`, `interval_days`,
  `next_review`, `review_count`), and summaries support categorization by type
  (thread, weekly, exam_guide).

- **LLM Integration**: Built `study_generator.py` using LangChain + Groq. Quizzes and
  flashcards are generated from ingested Piazza post chunks with structured JSON output
  parsing and fenced-block fallback extraction. Summaries are streamed. Pydantic
  TypeAdapters are used to inject JSON schema into prompts for reliable structured output.

- **Backend Endpoints** (`study_materials.py`): Full REST API covering:
  - `POST /quiz/generate` — generate and persist a quiz from course posts
  - `POST /quiz/submit` — submit answers, calculate and store score
  - `GET  /quiz/{id}/results` — retrieve attempt results
  - `DELETE /quiz/{id}` — delete a quiz
  - `POST /flashcard/generate` — generate a flashcard deck
  - `POST /flashcard/review` — submit a card review and apply SM-2 update
  - `GET  /flashcard/deck/{id}` — retrieve a deck with due cards
  - `DELETE /flashcard/deck/{id}` — delete a deck
  - `POST /summary/generate` — generate and store a summary (streamed LLM)
  - `DELETE /summary/{id}` — delete a summary
  - `GET  /study/all` — dashboard endpoint returning all materials for the user

  All routes are protected by JWT auth via `get_current_user`.

- **Pydantic Models** (`models/study_materials.py`): Comprehensive request/response models
  for all study material types including `QuizQuestion`, `FlashcardCard`, and nested
  response shapes.

- **Frontend** (`StudyMaterialsPage.jsx`, ~1400 lines): Tabbed UI for Quizzes, Flashcards,
  and Summaries. Includes an interactive quiz-taking flow with per-question scoring and
  result breakdown, flashcard flip animations with easy/medium/hard spaced repetition
  rating buttons, and collapsible summary cards. All wired to the backend API with auth
  headers.

- **Chrome Extension**: Added a standalone Study Tab (`studytab/`) as a dedicated extension
  page with its own HTML entry point and React root. Registered in `manifest.json` and
  bundled as a separate webpack entry.

## Test plan

- [ ] Run Supabase migration and verify all 5 tables are created with correct schemas and FK constraints
- [ ] Test quiz generation with easy/medium/hard difficulty and with/without source post filters
- [ ] Submit a quiz attempt and verify score calculation and persistence in `quiz_attempts`
- [ ] Generate a flashcard deck and complete a spaced repetition review session; confirm SM-2 fields update correctly
- [ ] Generate summaries for each type (thread, weekly, exam_guide) and confirm content is stored
- [ ] Open the Study Tab from the Chrome extension; confirm all three tabs render and load existing materials
- [ ] Verify the `/study/all` dashboard endpoint returns quizzes, decks, and summaries for the authenticated user
- [ ] Confirm auth middleware rejects unauthenticated requests with 401




